### PR TITLE
chore(ui): halve default grid unit size

### DIFF
--- a/packages/client/app/components/asset-manager/src/ui/ActionButton.jsx
+++ b/packages/client/app/components/asset-manager/src/ui/ActionButton.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 
 import styled from 'styled-components'
-import { th, darken } from '@coko/client'
+import { grid, th, darken } from '@coko/client'
 
 const Button = styled.button`
   align-items: center;
@@ -21,8 +21,8 @@ const Button = styled.button`
   display: flex;
   flex-basis: fit-content;
   justify-content: center;
-  margin-right: calc(2 * ${th('gridUnit')});
-  padding: calc(${th('gridUnit')} / 2) ${th('gridUnit')};
+  margin-right: ${grid(4)};
+  padding: ${grid(1)} ${grid(2)};
 
   &:focus {
     outline: 0;

--- a/packages/client/app/components/asset-manager/src/ui/ActionSection.jsx
+++ b/packages/client/app/components/asset-manager/src/ui/ActionSection.jsx
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
   width: 100%;
 
   button:not(:last-child) {
-    margin-right: ${grid(1)};
+    margin-right: ${grid(2)};
   }
 `
 

--- a/packages/client/app/components/asset-manager/src/ui/Button.jsx
+++ b/packages/client/app/components/asset-manager/src/ui/Button.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 
 import styled from 'styled-components'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 
 const Button = styled.button`
   /* stylelint-disable declaration-no-important */
@@ -12,7 +12,7 @@ const Button = styled.button`
   display: flex;
   font-family: 'Fira Sans Condensed', sans-serif !important;
   padding: 0;
-  /* padding: calc(${th('gridUnit')} / 2); */
+
   svg {
     svg {
       path {
@@ -68,22 +68,20 @@ const Button = styled.button`
 /* stylelint-enable declaration-no-important */
 
 const Icon = styled.span`
-  height: calc(3.5 * ${th('gridUnit')});
-  /* margin: 0 ${th('gridUnit')} 0 0; */
+  height: ${grid(7)};
   padding: 0;
-  width: calc(3.5 * ${th('gridUnit')});
+  width: ${grid(7)};
 `
 
 const OnlyIcon = styled.span`
-  height: calc(3.5 * ${th('gridUnit')});
+  height: ${grid(7)};
   padding: 0;
-  width: calc(3.5 * ${th('gridUnit')});
+  width: ${grid(7)};
 `
 
 const Label = styled.div`
   font-size: ${th('fontSizeBase')};
   line-height: ${th('lineHeightBase')};
-  /* padding-right: 4px; */
 `
 
 const ButtonWithIcon = ({

--- a/packages/client/app/components/asset-manager/src/ui/FilesTable.jsx
+++ b/packages/client/app/components/asset-manager/src/ui/FilesTable.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 
 import styled, { useTheme } from 'styled-components'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 import { indexOf } from 'lodash'
 
 import { dateTimeFormatter, fileSizeFormatter } from './helpers'
@@ -54,7 +54,7 @@ const TableBodyEmpty = styled.div`
   font-size: ${th('fontSizeBase')};
   justify-content: center;
   line-height: ${th('lineHeightBase')};
-  margin-top: calc(2 * ${th('gridUnit')});
+  margin-top: ${grid(4)};
   width: 100%;
 `
 

--- a/packages/client/app/components/asset-manager/src/ui/Modal/ModalFooter.jsx
+++ b/packages/client/app/components/asset-manager/src/ui/Modal/ModalFooter.jsx
@@ -10,7 +10,7 @@ const Wrapper = styled.div`
   justify-content: flex-end;
 
   > button {
-    margin-right: ${grid(1)};
+    margin-right: ${grid(2)};
   }
 `
 

--- a/packages/client/app/components/asset-manager/src/ui/Modal/ModalRoot.jsx
+++ b/packages/client/app/components/asset-manager/src/ui/Modal/ModalRoot.jsx
@@ -28,31 +28,31 @@ const ReactModalAdapter = ({ className, modalClassName, ...props }) => {
 
 const large = css`
   height: calc(640px - 16px);
-  margin: ${grid(5)} auto;
+  margin: ${grid(10)} auto;
   width: calc(1144px - 16px);
 `
 
 const largeNarrow = css`
   height: calc(640px - 16px);
-  margin: ${grid(5)} auto;
+  margin: ${grid(10)} auto;
   width: calc(1000px - 16px);
 `
 
 const medium = css`
   height: calc(536px - 16px);
-  margin: ${grid(7)} auto;
+  margin: ${grid(14)} auto;
   width: calc(936px - 16px);
 `
 
 const mediumNarrow = css`
   height: calc(536px - 16px);
-  margin: ${grid(7)} auto;
+  margin: ${grid(14)} auto;
   width: calc(752px - 16px);
 `
 
 const small = css`
   height: calc(248px - 16px);
-  margin: ${grid(8)} auto;
+  margin: ${grid(16)} auto;
   width: calc(496px - 16px);
 `
 
@@ -76,7 +76,7 @@ const StyledModal = styled(ReactModalAdapter).attrs({
     flex-direction: column;
     outline: none;
     overflow: hidden;
-    padding: ${grid(1)};
+    padding: ${grid(2)};
 
     /* stylelint-disable order/properties-alphabetical-order */
     ${props => (props.size === 'large' ? large : '')}

--- a/packages/client/app/components/asset-manager/src/ui/Modal/RootButton.jsx
+++ b/packages/client/app/components/asset-manager/src/ui/Modal/RootButton.jsx
@@ -34,7 +34,7 @@ const RootButton = styled.button.attrs(({ title, type }) => ({
   font-size: ${th('fontSizeBase')};
   justify-content: center;
   outline: none;
-  padding: ${grid(0.5)};
+  padding: ${grid(1)};
   transition: all 0.1s ease-in;
 
   > i svg {

--- a/packages/client/app/components/component-author-feedback/src/components/ReadOnlyAuthorFeedback.jsx
+++ b/packages/client/app/components/component-author-feedback/src/components/ReadOnlyAuthorFeedback.jsx
@@ -10,9 +10,9 @@ import SubmittedStatus from './SubmittedStatus'
 import SimpleWaxEditor from '../../../wax-collab/src/SimpleWaxEditor'
 
 const Content = styled(PaddedContent)`
-  margin-bottom: ${grid(1)};
-  margin-top: ${grid(1)};
-  padding: ${grid(1)} ${grid(3)};
+  margin-bottom: ${grid(2)};
+  margin-top: ${grid(2)};
+  padding: ${grid(2)} ${grid(6)};
 `
 
 const ReadOnlyAuthorFeedback = ({ authorFeedback, allFiles }) => {

--- a/packages/client/app/components/component-chat/src/MessageContainer.jsx
+++ b/packages/client/app/components/component-chat/src/MessageContainer.jsx
@@ -6,7 +6,7 @@
 
 import React from 'react'
 import styled, { css } from 'styled-components'
-import { th, grid } from '@coko/client'
+import { grid } from '@coko/client'
 import { useLocation } from 'react-router-dom'
 import { HiddenTabs } from '../../shared'
 import Chat from './Chat'
@@ -21,10 +21,10 @@ const MessageContainer = styled.section`
   ${props =>
     props.$channels
       ? css`
-          grid-template-rows: ${grid(5)} 1fr calc(${th('gridUnit')} * 8);
+          grid-template-rows: ${grid(10)} 1fr ${grid(16)};
         `
       : css`
-          grid-template-rows: 1fr calc(${th('gridUnit')} * 8);
+          grid-template-rows: 1fr ${grid(16)};
         `}
 
   ${props =>

--- a/packages/client/app/components/component-chat/src/Messages/style.jsx
+++ b/packages/client/app/components/component-chat/src/Messages/style.jsx
@@ -229,7 +229,7 @@ export const Ellipsis = styled(MoreVertical)`
   border-radius: 50%;
   cursor: pointer;
   height: 20.25px;
-  margin: ${grid(0.25)} ${grid(1)} ${grid(1)} ${grid(2)};
+  margin: ${grid(0.5)} ${grid(2)} ${grid(2)} ${grid(4)};
   padding: 3px;
   position: absolute;
   right: 0;

--- a/packages/client/app/components/component-chat/src/SuperChatInput/ToolbarButton.jsx
+++ b/packages/client/app/components/component-chat/src/SuperChatInput/ToolbarButton.jsx
@@ -15,7 +15,7 @@ const Button = styled.a`
   border: 1px solid ${th('color.gray50')};
   border-radius: 10px;
   height: fit-content;
-  margin: ${grid(1)} ${grid(1)} 0 0;
+  margin: ${grid(2)} ${grid(2)} 0 0;
   padding: 4px 0;
 
   &:hover {

--- a/packages/client/app/components/component-chat/src/SuperChatInput/style.jsx
+++ b/packages/client/app/components/component-chat/src/SuperChatInput/style.jsx
@@ -2,7 +2,7 @@
 /* stylelint-disable declaration-no-important, string-quotes */
 
 import styled, { css } from 'styled-components'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 import { MEDIA_BREAK } from '../../../layout'
 import { zIndex } from '../../../../globals'
 
@@ -129,7 +129,7 @@ export const ChatInputWrapper = styled.div`
   background-color: ${th('colorBackground')};
   display: flex;
   flex-direction: row;
-  margin-bottom: ${th('gridUnit')};
+  margin-bottom: ${grid(2)};
   padding: 8px 4px 0;
   width: 100%;
 
@@ -154,7 +154,7 @@ export const Form = styled.form`
 
   & > button {
     /* Make height of button consistent with the Input Box */
-    padding: 10px ${th('gridUnit')};
+    padding: 10px ${grid(2)};
   }
 `
 

--- a/packages/client/app/components/component-chat/src/VideoChat.jsx
+++ b/packages/client/app/components/component-chat/src/VideoChat.jsx
@@ -11,7 +11,7 @@ import { ConfigContext } from '../../config/src'
 const FloatRightButton = styled(RoundIconButton).attrs({
   'data-testid': 'float-right-button',
 })`
-  margin: ${grid(1)} ${grid(1)} ${grid(1)} ${grid(2)};
+  margin: ${grid(2)} ${grid(2)} ${grid(2)} ${grid(4)};
   position: absolute;
   right: 42px;
   z-index: 1000;

--- a/packages/client/app/components/component-cms-manager/src/CMSPagesPage.jsx
+++ b/packages/client/app/components/component-cms-manager/src/CMSPagesPage.jsx
@@ -39,7 +39,7 @@ const EditPageRight = styled(BaseEditPageRight)`
 
   /* stylelint-disable-next-line selector-class-pattern */
   .ProseMirror {
-    padding: ${grid(2)};
+    padding: ${grid(4)};
   }
 `
 

--- a/packages/client/app/components/component-cms-manager/src/article/article.jsx
+++ b/packages/client/app/components/component-cms-manager/src/article/article.jsx
@@ -26,7 +26,7 @@ import ManuscriptMetadata from './ManuscriptMetadata'
 
 const Tabs = styled.div`
   display: flex;
-  margin-top: ${grid(1)};
+  margin-top: ${grid(2)};
 `
 
 const TabRow = styled(FlexRow)`
@@ -34,7 +34,7 @@ const TabRow = styled(FlexRow)`
 `
 
 const PublishButton = styled(FormActionButton)`
-  margin-bottom: ${grid(1)};
+  margin-bottom: ${grid(2)};
   margin-left: auto;
   margin-right: 0;
 `

--- a/packages/client/app/components/component-cms-manager/src/collection/CollectionList.jsx
+++ b/packages/client/app/components/component-cms-manager/src/collection/CollectionList.jsx
@@ -39,7 +39,7 @@ export const CollectionsHeading = styled.div`
   align-items: center;
   background-color: ${th('color.backgroundA')};
   border-top: 1px solid ${th('color.gray90')};
-  column-gap: ${grid(2)};
+  column-gap: ${grid(4)};
   display: flex;
   flex-direction: row;
   line-height: 1.4em;
@@ -48,11 +48,11 @@ export const CollectionsHeading = styled.div`
 
   &:first-child {
     border-top: none;
-    padding: ${grid(0.5)} ${grid(2)};
+    padding: ${grid(1)} ${grid(4)};
   }
 
   &:not(:first-child) {
-    padding: ${grid(1.5)} ${grid(2)};
+    padding: ${grid(3)} ${grid(4)};
   }
 `
 

--- a/packages/client/app/components/component-cms-manager/src/editor/EditorStyles.jsx
+++ b/packages/client/app/components/component-cms-manager/src/editor/EditorStyles.jsx
@@ -59,7 +59,7 @@ export const EditorDiv = styled.div`
   height: 100%;
   ${props => !props.$hideComments && 'min-width: 800px'};
   overflow: auto;
-  padding: ${grid(2)};
+  padding: ${grid(4)};
   position: relative;
 
   .error & {

--- a/packages/client/app/components/component-cms-manager/src/layout/PartnerListItem.jsx
+++ b/packages/client/app/components/component-cms-manager/src/layout/PartnerListItem.jsx
@@ -12,16 +12,16 @@ import { ConfirmationModal } from '../../../component-modal/src/ConfirmationModa
 
 const Icon = styled.div`
   background: ${th('colorFurniture')};
-  height: ${grid(10)};
-  margin-bottom: ${th('gridUnit')};
+  height: ${grid(20)};
+  margin-bottom: ${grid(2)};
   opacity: 0.5;
   overflow: hidden;
-  padding: ${grid(1)};
+  padding: ${grid(2)};
   position: relative;
-  width: ${grid(10)};
+  width: ${grid(20)};
 
   img {
-    width: ${grid(8)};
+    width: ${grid(16)};
   }
 `
 
@@ -29,20 +29,20 @@ const Extension = styled.div`
   background: ${th('colorText')};
   color: ${th('colorTextReverse')};
   font-size: ${th('fontSizeBaseSmall')};
-  left: ${grid(2)};
+  left: ${grid(4)};
   line-height: ${th('lineHeightBaseSmall')};
   position: absolute;
   right: 0;
   text-align: center;
   text-transform: uppercase;
-  top: ${grid(2)};
+  top: ${grid(4)};
 `
 
 const Filename = styled.div`
   color: ${th('colorText')};
   font-size: ${th('fontSizeBaseSmall')};
   font-style: italic;
-  height: ${grid(2)};
+  height: ${grid(4)};
   line-height: ${th('lineHeightBaseSmall')};
   overflow: auto;
   text-overflow: ellipsis;
@@ -55,8 +55,8 @@ const Uploading = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin-right: ${grid(4)};
-  min-width: ${grid(28)};
+  margin-right: ${grid(8)};
+  min-width: ${grid(56)};
   padding: 16px;
   position: relative;
 `
@@ -86,7 +86,7 @@ const URLInput = styled(TextInput)`
       border: 2px solid red !important;
     `}
 
-  padding: ${grid(1)};
+  padding: ${grid(2)};
 `
 
 const getFileExtension = ({ name }) => name.replace(/^.+\./, '')

--- a/packages/client/app/components/component-cms-manager/src/layout/PartnerListing.jsx
+++ b/packages/client/app/components/component-cms-manager/src/layout/PartnerListing.jsx
@@ -15,9 +15,9 @@ import PartnerListItem from './PartnerListItem'
 
 const Files = styled.div`
   display: flex;
-  gap: ${grid(2)};
+  gap: ${grid(4)};
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  margin-top: ${grid(2)};
+  margin-top: ${grid(4)};
   overflow: auto;
 `
 

--- a/packages/client/app/components/component-cms-manager/src/pages/CMSPageEditSidebar.jsx
+++ b/packages/client/app/components/component-cms-manager/src/pages/CMSPageEditSidebar.jsx
@@ -8,8 +8,8 @@ import { Heading2, SidebarPageRow, RightArrow } from '../style'
 import { RoundIconButton } from '../../../shared'
 
 const AddNewPage = styled(RoundIconButton)`
-  margin-left: ${grid(1)};
-  margin-top: ${grid(2)};
+  margin-left: ${grid(2)};
+  margin-top: ${grid(4)};
   min-width: 0;
 `
 

--- a/packages/client/app/components/component-cms-manager/src/style.jsx
+++ b/packages/client/app/components/component-cms-manager/src/style.jsx
@@ -168,13 +168,13 @@ export const SimpleWaxEditorContainer = styled.div`
 export const ControlsContainer = styled.div`
   display: flex;
   flex: 1 1;
-  gap: ${grid(2)};
+  gap: ${grid(4)};
   justify-content: flex-end;
 `
 
 export const FlexRow = styled.div`
   display: flex;
-  gap: ${grid(1)};
+  gap: ${grid(2)};
   justify-content: space-between;
 `
 
@@ -201,8 +201,8 @@ export const ErrorMessage = styled.div`
 export const InfoBlock = styled.div`
   background-color: ${th('colorSecondaryBackground')};
   border: 1px solid ${th('colorBorder')};
-  border-radius: ${grid(1)};
-  padding: ${grid(2)};
+  border-radius: ${grid(2)};
+  padding: ${grid(4)};
   width: 100%;
 `
 
@@ -218,30 +218,30 @@ export const LayoutHeaderListContainer = styled.div`
 export const LayoutHeaderListItem = styled.div`
   align-items: center;
   border: 1px solid #dedede;
-  border-radius: ${grid(1)};
+  border-radius: ${grid(2)};
   display: flex;
   justify-content: space-between;
-  margin-bottom: ${grid(2)};
-  padding: ${grid(1 / 2)};
+  margin-bottom: ${grid(4)};
+  padding: ${grid(1)};
   user-select: none;
 `
 
 export const LayoutMainHeading = styled(Heading)`
   color: ${th('colorTextPlaceholder')};
-  font-size: ${grid(3)};
-  margin-bottom: ${grid(2)};
+  font-size: ${grid(6)};
+  margin-bottom: ${grid(4)};
 `
 
 export const LayoutSecondaryHeading = styled(Heading)`
   color: ${th('colorTextPlaceholder')};
-  font-size: ${grid(1.5)};
-  margin-bottom: ${grid(1)};
+  font-size: ${grid(3)};
+  margin-bottom: ${grid(2)};
 `
 export const RightArrow = styled(ChevronRight)`
-  height: ${grid(2)};
+  height: ${grid(4)};
   margin-bottom: 12px;
   margin-top: 12px;
   stroke: ${th('colorPrimary')};
   stroke-width: 4px;
-  width: ${grid(2)};
+  width: ${grid(4)};
 `

--- a/packages/client/app/components/component-config-manager/src/ConfigManagerForm.jsx
+++ b/packages/client/app/components/component-config-manager/src/ConfigManagerForm.jsx
@@ -46,7 +46,7 @@ const StyledContainer = styled.div`
 const StyledSectionContent = styled(SectionContent)`
   margin: 0;
   overflow-y: auto;
-  padding: ${grid(3.75)} ${grid(3.75)} 0 ${grid(3.75)};
+  padding: ${grid(7.5)} ${grid(7.5)} 0 ${grid(7.5)};
   width: 100%;
 `
 
@@ -102,7 +102,7 @@ const EmailsTabWrapper = styled(StyledSectionContent)`
 
   /* stylelint-disable-next-line selector-class-pattern */
   .ProseMirror {
-    padding: ${grid(1)} ${grid(2)};
+    padding: ${grid(2)} ${grid(4)};
 
     span.handlebars {
       background-color: ${getFormBadgeBg('common')};
@@ -147,7 +147,7 @@ const StyledWrapper = styled.div`
     p.$showGap &&
     css`
       display: grid;
-      gap: ${grid(2)};
+      gap: ${grid(4)};
     `}
 
   /* stylelint-disable-next-line selector-id-pattern */

--- a/packages/client/app/components/component-config-manager/src/ui/CoarAuthToken.jsx
+++ b/packages/client/app/components/component-config-manager/src/ui/CoarAuthToken.jsx
@@ -9,13 +9,13 @@ import { TextField } from '../../../pubsweet'
 const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${grid(2)};
+  gap: ${grid(4)};
   width: 100%;
 `
 
 const CoarAuthFieldWrapper = styled.div`
   display: flex;
-  gap: ${grid(2)};
+  gap: ${grid(4)};
   width: 100%;
 `
 
@@ -24,7 +24,7 @@ const StyledTextField = styled(TextField)`
 `
 
 const StyledActionButton = styled(ActionButton)`
-  padding: 0 ${grid(2)};
+  padding: 0 ${grid(4)};
 `
 
 const CoarAuthToken = ({ onRefreshCoarAuthToken }) => {

--- a/packages/client/app/components/component-dashboard/src/components/DashboardLayout.jsx
+++ b/packages/client/app/components/component-dashboard/src/components/DashboardLayout.jsx
@@ -26,7 +26,7 @@ const TabLink = styled(Link)`
 
 const Tabs = styled.div`
   display: flex;
-  margin-top: ${grid(1)};
+  margin-top: ${grid(2)};
 `
 
 const TabRow = styled(FlexRow)`
@@ -35,7 +35,7 @@ const TabRow = styled(FlexRow)`
 
 const RightControls = styled(ControlsContainer)`
   margin-left: auto;
-  margin-bottom: ${grid(1)};
+  margin-bottom: ${grid(2)};
 `
 
 const DashboardLayout = ({ children }) => {

--- a/packages/client/app/components/component-dashboard/src/style.jsx
+++ b/packages/client/app/components/component-dashboard/src/style.jsx
@@ -13,7 +13,7 @@ export { Actions, ActionContainer }
 const Item = styled.div`
   display: grid;
   grid-template-columns: 1fr auto;
-  margin-bottom: ${grid(4)};
+  margin-bottom: ${grid(8)};
 `
 
 const Header = styled.div`
@@ -26,7 +26,7 @@ const Header = styled.div`
 const Body = styled.div`
   display: flex;
   justify-content: space-between;
-  margin-bottom: calc(${th('gridUnit')} * 4);
+  margin-bottom: ${grid(8)};
   padding-left: 1.5em;
 
   & > div:last-child {
@@ -56,7 +56,7 @@ const LinkContainer = styled.div`
 export { Links, LinkContainer }
 
 const Page = styled.div`
-  padding: ${grid(2)};
+  padding: ${grid(4)};
 `
 
 const Heading = styled.div`
@@ -95,12 +95,12 @@ export const InvitationContent = styled.div`
   max-height: calc(100vh - 32px);
   max-width: 50em;
   overflow-y: auto;
-  padding: ${grid(4)};
+  padding: ${grid(8)};
   text-align: center;
   width: 800px;
 
   h1 {
-    margin-bottom: ${grid(2)};
+    margin-bottom: ${grid(4)};
   }
 
   img {

--- a/packages/client/app/components/component-email-templates/misc/styleds.jsx
+++ b/packages/client/app/components/component-email-templates/misc/styleds.jsx
@@ -16,7 +16,7 @@ export const CleanButton = styled.button.attrs({ type: 'button' })`
   border: none;
   cursor: ${p => (p.$disabled ? 'not-allowed' : 'pointer')};
   display: ${p => (p.$hide ? 'none' : 'flex')};
-  gap: ${grid(1)};
+  gap: ${grid(2)};
   justify-content: flex-start;
   opacity: ${p => (p.$disabled ? 0.5 : 1)};
   outline: none;
@@ -42,7 +42,7 @@ export const Content = styled(EditPageContainer)`
 export const EditSection = styled(EditPageRight)`
   background-color: #fff;
   overflow: visible;
-  padding: ${grid(3)} ${grid(6)};
+  padding: ${grid(6)} ${grid(12)};
 `
 // #endregion EmailTemplatesContent --------------------------------------------------------------------
 
@@ -54,12 +54,12 @@ export const StyledPage = styled(Page)`
 
 export const StyledEditorForm = styled(EditorForm)`
   height: inherit;
-  padding: 0 ${grid(3)};
+  padding: 0 ${grid(6)};
 `
 
 export const Footer = styled(FlexRow)`
   justify-content: flex-start;
-  padding: ${grid(3)};
+  padding: ${grid(6)};
 `
 
 // #endregion EmailTemplatesEditForm --------------------------------------------------------------------
@@ -70,7 +70,7 @@ export const Action = styled(CleanButton)`
   color: ${p =>
     p.disabled ? p.theme.color.gray80 : p.theme.color.brand1.base};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
-  gap: ${grid(1)};
+  gap: ${grid(2)};
   min-width: 0;
   width: fit-content;
 
@@ -87,17 +87,17 @@ export const HeaderRoot = styled.header`
   background: #fff;
   border-bottom: 1px solid #ddd;
   display: flex;
-  gap: ${grid(1)};
+  gap: ${grid(2)};
   justify-content: space-between;
   margin: 0;
-  padding: ${grid(0.5)} ${grid(1.5)};
+  padding: ${grid(1)} ${grid(3)};
 `
 export const CreateButton = styled(ActionButton)`
   align-items: center;
   display: flex;
   height: fit-content;
   justify-content: center;
-  margin-right: ${grid(1)};
+  margin-right: ${grid(2)};
   text-align: center;
 `
 
@@ -108,19 +108,19 @@ export const Heading = styled.h3`
 `
 
 export const ActionContainer = styled(FlexRow)`
-  gap: ${grid(1.5)};
+  gap: ${grid(3)};
 `
 
 export const DescriptionContainer = styled(FlexRow)`
   flex-direction: column;
   gap: 2px;
-  padding: ${grid(1.5)} ${grid(3)};
+  padding: ${grid(3)} ${grid(6)};
 `
 
 export const EditedOnLabel = styled.small`
   color: ${th('color.gray20')};
   line-height: 1.2;
-  padding: ${grid(0.25)} 0 0;
+  padding: ${grid(0.5)} 0 0;
 `
 // #endregion EmailTemplatesHeader --------------------------------------------------------------------
 
@@ -142,9 +142,9 @@ export const ListHeader = styled(CleanButton)`
   border-left: 1px solid #ddd;
   color: #555;
   font-weight: bold;
-  gap: ${grid(1)};
+  gap: ${grid(2)};
   justify-content: space-between;
-  padding: ${grid(1)} ${grid(2)};
+  padding: ${grid(2)} ${grid(4)};
   text-transform: uppercase;
   z-index: 9;
 
@@ -185,7 +185,7 @@ export const OptionListItem = styled.li`
   font-weight: ${p => (p.$selected ? 'bold' : 'normal')};
   justify-content: space-between;
   margin: 0;
-  padding: ${grid(1)} ${grid(2.05)};
+  padding: ${grid(2)} ${grid(4.1)};
   width: 100%;
 
   svg {
@@ -203,7 +203,7 @@ export const OptionListItem = styled.li`
 
 export const OptionListItemButton = styled(CleanButton)`
   color: ${p => (p.$warning ? p.theme.color.warning.base : '#555')};
-  gap: ${grid(1.5)};
+  gap: ${grid(3)};
   width: 100%;
 
   p {
@@ -212,7 +212,7 @@ export const OptionListItemButton = styled(CleanButton)`
     margin: 0;
     max-width: 240px;
     overflow: hidden;
-    padding-left: ${grid(2)};
+    padding-left: ${grid(4)};
     text-decoration: ${p => (p.$warning ? 'line-through' : 'none')};
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/packages/client/app/components/component-email-templates/src/handlebarsAutocomplete/components/HandleBarsAutocomplete.jsx
+++ b/packages/client/app/components/component-email-templates/src/handlebarsAutocomplete/components/HandleBarsAutocomplete.jsx
@@ -33,7 +33,7 @@ const OptionsDropdown = styled(FlexRow)`
 const Heading = styled(FlexRow)`
   background-color: ${th('color.brand1.shade25')};
   color: #fff;
-  padding: ${grid(0.5)} ${grid(1.2)};
+  padding: ${grid(1)} ${grid(2.4)};
   width: 100%;
 `
 

--- a/packages/client/app/components/component-email-templates/src/handlebarsAutocomplete/components/Option.jsx
+++ b/packages/client/app/components/component-email-templates/src/handlebarsAutocomplete/components/Option.jsx
@@ -26,7 +26,7 @@ const OptionButton = styled.button`
   border: none;
   border-right: 1px solid ${th('color.brand1.tint70')};
   cursor: pointer;
-  padding: ${grid(1.5)} ${grid(2)};
+  padding: ${grid(3)} ${grid(4)};
   scroll-snap-align: start;
   text-align: left;
   width: 100%;
@@ -43,7 +43,7 @@ const OptionButton = styled.button`
 const OptionContent = styled(FlexRow)`
   align-items: center;
   display: flex;
-  gap: ${grid(5)};
+  gap: ${grid(10)};
   justify-content: space-between;
   pointer-events: none;
   width: 100%;
@@ -69,7 +69,7 @@ const FormBadge = styled.span`
   font-size: ${th('fontSizeBaseSmaller')};
   line-height: 1;
   min-width: 80px;
-  padding: ${grid(0.6)} ${grid(0.8)};
+  padding: ${grid(1.2)} ${grid(1.6)};
   text-align: center;
   text-rendering: optimizelegibility;
 `

--- a/packages/client/app/components/component-formbuilder/src/components/FormBuilder.jsx
+++ b/packages/client/app/components/component-formbuilder/src/components/FormBuilder.jsx
@@ -22,7 +22,7 @@ const FeildWrapper = styled.div`
   align-items: center;
   border-radius: ${th('borderRadius')};
   display: flex;
-  padding: ${grid(0.5)};
+  padding: ${grid(1)};
 
   &.active {
     background-color: ${th('color.brand1.tint70')};
@@ -54,12 +54,12 @@ const MainAction = styled(Action)`
 
 const IconAction = styled(Action)`
   flex-grow: 0;
-  margin: 0 ${grid(1)};
+  margin: 0 ${grid(2)};
 `
 
 const DragIcon = styled(DragVerticalIcon)`
   height: 20px;
-  margin-right: ${grid(1)};
+  margin-right: ${grid(2)};
   stroke: transparent;
   width: 20px;
 `

--- a/packages/client/app/components/component-formbuilder/src/components/FormSettingsModal.jsx
+++ b/packages/client/app/components/component-formbuilder/src/components/FormSettingsModal.jsx
@@ -23,11 +23,11 @@ const InvalidWarning = styled.div`
 export const Legend = styled.div`
   font-size: ${th('fontSizeBase')};
   font-weight: 600;
-  margin-bottom: ${({ space, theme }) => space && theme.gridUnit};
+  margin-bottom: ${props => props.space && grid(2)(props)};
 `
 
 export const Section = styled.div`
-  margin: ${grid(4)} 0;
+  margin: ${grid(8)} 0;
 
   &:first-child {
     margin-top: 0;

--- a/packages/client/app/components/component-formbuilder/src/components/builderComponents/OptionsField.jsx
+++ b/packages/client/app/components/component-formbuilder/src/components/builderComponents/OptionsField.jsx
@@ -63,12 +63,12 @@ const InlineColorPicker = styled(Inline)`
   & > div {
     font-size: ${th('fontSizeBaseSmall')};
     line-height: ${th('lineHeightBaseSmall')};
-    margin-bottom: ${grid(1)};
+    margin-bottom: ${grid(2)};
   }
 
   & input {
-    height: ${grid(6)};
-    width: ${grid(9)};
+    height: ${grid(12)};
+    width: ${grid(18)};
   }
 `
 

--- a/packages/client/app/components/component-formbuilder/src/components/builderComponents/RadioBoxS3Service.jsx
+++ b/packages/client/app/components/component-formbuilder/src/components/builderComponents/RadioBoxS3Service.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import styled from 'styled-components'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 import Flexbox from '../../../../pubsweet/Flexbox'
 import Radio from '../../../../pubsweet/Radio'
 import { TextField } from '../../../../pubsweet'
@@ -11,7 +11,7 @@ import { ActionButton } from '../../../../shared'
 export const Legend = styled.div`
   font-size: ${th('fontSizeBase')};
   font-weight: 600;
-  margin-bottom: ${({ space, theme }) => space && theme.gridUnit};
+  margin-bottom: ${props => props.space && grid(2)(props)};
 `
 
 const CredentialsFlexbox = styled(Flexbox)`

--- a/packages/client/app/components/component-formbuilder/src/components/style.jsx
+++ b/packages/client/app/components/component-formbuilder/src/components/style.jsx
@@ -3,7 +3,7 @@ import { th, grid } from '@coko/client'
 import { Button } from '../../../pubsweet'
 
 export const Section = styled.div`
-  margin: ${grid(4)} 0;
+  margin: ${grid(8)} 0;
 
   &:first-child {
     margin-top: 0;
@@ -11,7 +11,7 @@ export const Section = styled.div`
 `
 
 export const Subsection = styled.div`
-  margin: 0 50% ${grid(4)} ${grid(4)};
+  margin: 0 50% ${grid(8)} ${grid(8)};
 `
 
 export const Legend = styled.div`
@@ -34,7 +34,7 @@ const Heading = styled.div`
   color: ${th('color.brand1.base')};
   font-family: ${th('fontReading')};
   font-size: ${th('fontSizeHeading3')};
-  margin: ${th('gridUnit')} 0;
+  margin: ${grid(2)} 0;
   text-transform: uppercase;
 `
 
@@ -63,7 +63,7 @@ const CommentMetaWrapper = styled.div`
 const UserMetaWrapper = styled.div`
   align-items: center;
   display: flex;
-  gap: ${grid(1)};
+  gap: ${grid(2)};
 `
 
 const UserName = styled.span`
@@ -166,7 +166,7 @@ const Collapse = styled.div`
 const ActionWrapper = styled.div`
   align-items: center;
   display: flex;
-  gap: ${grid(4)};
+  gap: ${grid(8)};
   justify-content: flex-end;
 
   svg {

--- a/packages/client/app/components/component-frontpage/src/Frontpage.jsx
+++ b/packages/client/app/components/component-frontpage/src/Frontpage.jsx
@@ -26,13 +26,13 @@ import PublishedArtifactWithLink from './PublishedArtifactWithLink'
 const ManuscriptBox = styled.div`
   border: 1px solid ${th('colorBorder')};
   border-radius: ${th('borderRadius')};
-  margin-bottom: ${grid(0.5)};
+  margin-bottom: ${grid(1)};
 `
 
 const Subheading = styled.h3`
   font-size: ${th('fontSizeHeading6')};
   font-weight: bold;
-  margin-top: ${grid(2.0)};
+  margin-top: ${grid(4)};
 `
 
 const LoginLink = styled.a`

--- a/packages/client/app/components/component-frontpage/src/GroupsPage.jsx
+++ b/packages/client/app/components/component-frontpage/src/GroupsPage.jsx
@@ -22,7 +22,7 @@ const Content = styled.div`
   margin-bottom: 1rem;
   max-width: 40em;
   min-width: 20em;
-  padding: ${grid(4)};
+  padding: ${grid(8)};
   text-align: left;
 `
 
@@ -32,7 +32,7 @@ const Centered = styled.div`
 
 const LoginSelect = styled(Select)`
   display: block;
-  margin-top: ${grid(1)};
+  margin-top: ${grid(2)};
   width: 100%;
 `
 

--- a/packages/client/app/components/component-frontpage/src/style.jsx
+++ b/packages/client/app/components/component-frontpage/src/style.jsx
@@ -6,7 +6,7 @@ export const Container = styled.div`
   max-height: 100vh;
   min-height: 100vh;
   overflow-y: scroll;
-  padding: ${grid(2)};
+  padding: ${grid(4)};
 `
 
 export const Placeholder = styled.div`
@@ -19,8 +19,8 @@ export const Placeholder = styled.div`
 
 export const VisualAbstract = styled.img`
   display: block;
-  max-height: ${grid(40)};
-  max-width: ${grid(40)};
+  max-height: ${grid(80)};
+  max-width: ${grid(80)};
 `
 
 export const Abstract = styled.div``

--- a/packages/client/app/components/component-login/src/Login.jsx
+++ b/packages/client/app/components/component-login/src/Login.jsx
@@ -49,7 +49,7 @@ const LoginButton = styled(Button).attrs({
   'data-testid': 'login-button',
 })`
   display: block;
-  margin-top: ${grid(3)};
+  margin-top: ${grid(6)};
   width: 100%;
 `
 
@@ -73,11 +73,11 @@ const Content = styled.div`
   box-shadow: ${th('boxShadow200')};
   margin-bottom: 1rem;
   max-width: 40em;
-  padding: ${grid(4)};
+  padding: ${grid(8)};
   text-align: center;
 
   h1 {
-    margin-bottom: ${grid(2)};
+    margin-bottom: ${grid(4)};
   }
 
   img {

--- a/packages/client/app/components/component-manuscripts-table/src/FilterSortHeader.jsx
+++ b/packages/client/app/components/component-manuscripts-table/src/FilterSortHeader.jsx
@@ -16,10 +16,10 @@ import {
 const CalendarIcon = styled(({ isActive, ...props }) => (
   <FeatherCalendar {...props} />
 ))`
-  height: ${grid(2)};
+  height: ${grid(4)};
   stroke: ${props =>
     props.isActive ? props.theme.color.brand1.base : props.theme.color.gray60};
-  width: ${grid(2)};
+  width: ${grid(4)};
 
   &:hover {
     stroke: ${th('color.brand1.base')};

--- a/packages/client/app/components/component-manuscripts-table/src/cell-components/StatusBadge.jsx
+++ b/packages/client/app/components/component-manuscripts-table/src/cell-components/StatusBadge.jsx
@@ -11,7 +11,7 @@ const Status = styled.span`
   ${props =>
     !props.minimal &&
     css`
-      padding: ${grid(0.5)} ${grid(1)};
+      padding: ${grid(1)} ${grid(2)};
     `}
 
   ${props =>

--- a/packages/client/app/components/component-manuscripts-table/src/style.jsx
+++ b/packages/client/app/components/component-manuscripts-table/src/style.jsx
@@ -62,7 +62,7 @@ export const ManuscriptsRow = styled.div.attrs({
       ? props.theme.color.warning.tint90
       : props.theme.color.backgroundA};
   border-top: 1px solid ${th('color.gray90')};
-  column-gap: ${grid(2)};
+  column-gap: ${grid(4)};
   display: flex;
   flex-direction: row;
   line-height: 1.4em;
@@ -71,11 +71,11 @@ export const ManuscriptsRow = styled.div.attrs({
 
   &:first-child {
     border-top: none;
-    padding: ${grid(0.5)} ${grid(2)};
+    padding: ${grid(1)} ${grid(4)};
   }
 
   &:not(:first-child) {
-    padding: ${grid(1.5)} ${grid(2)};
+    padding: ${grid(3)} ${grid(4)};
   }
 `
 
@@ -96,7 +96,7 @@ export const ClickableManuscriptsRow = styled(ManuscriptsRow).attrs({
 export const SnippetRow = styled.div`
   background-color: ${th('colorSecondaryBackground')};
   color: ${th('colorIconPrimary')};
-  padding: ${grid(0.5)} ${grid(4)};
+  padding: ${grid(1)} ${grid(8)};
   text-align: left;
   width: 100%;
 `

--- a/packages/client/app/components/component-manuscripts/src/Manuscripts.jsx
+++ b/packages/client/app/components/component-manuscripts/src/Manuscripts.jsx
@@ -57,14 +57,14 @@ const ManuscriptsPane = styled.div`
 
 const FlexRow = styled.div`
   display: flex;
-  gap: ${grid(1)};
+  gap: ${grid(2)};
   justify-content: flex-end;
 `
 
 const FlexRowWithSmallGapAbove = styled(FlexRow)`
   align-items: end;
   justify-content: flex-start;
-  margin-bottom: ${grid(1)};
+  margin-bottom: ${grid(2)};
 `
 
 const RoundIconButtonWrapper = styled(RoundIconButton).attrs({

--- a/packages/client/app/components/component-manuscripts/src/SearchControl.jsx
+++ b/packages/client/app/components/component-manuscripts/src/SearchControl.jsx
@@ -14,7 +14,7 @@ const SearchContainer = styled.div`
   align-items: center;
   display: flex;
   flex: 0 1 ${props => (props.$isOpen ? '40em' : '')};
-  gap: ${grid(1)};
+  gap: ${grid(2)};
   justify-content: flex-end;
 `
 
@@ -30,7 +30,7 @@ const InlineTextField = styled.input`
   border-radius: ${th('borderRadius')};
   display: inline;
   flex: 0 1 40em;
-  height: ${grid(4)};
+  height: ${grid(8)};
   padding: 0 8px;
   transition: ${th('transitionDuration')} ${th('transitionTimingFunction')};
 

--- a/packages/client/app/components/component-manuscripts/src/style.jsx
+++ b/packages/client/app/components/component-manuscripts/src/style.jsx
@@ -21,7 +21,7 @@ export const SelectedManuscriptsNumber = styled.p.attrs({
 export const ControlsContainer = styled.div`
   display: flex;
   flex: 1 1;
-  gap: ${grid(2)};
+  gap: ${grid(4)};
   justify-content: flex-end;
 `
 

--- a/packages/client/app/components/component-modal/src/ConfirmationModal.jsx
+++ b/packages/client/app/components/component-modal/src/ConfirmationModal.jsx
@@ -30,7 +30,7 @@ const ModalContainer = styled.div.attrs({
 })`
   background-color: ${th('colorBackground')};
   border-radius: ${th('borderRadius')};
-  padding: ${grid(2.5)} ${grid(3)};
+  padding: ${grid(5)} ${grid(6)};
   z-index: 10000;
 `
 
@@ -40,7 +40,7 @@ const MessageString = styled.div.attrs({
   align-items: center;
   display: flex;
   justify-content: center;
-  margin-bottom: ${grid(2.5)};
+  margin-bottom: ${grid(5)};
   width: 100%;
 `
 

--- a/packages/client/app/components/component-modal/src/Modal.jsx
+++ b/packages/client/app/components/component-modal/src/Modal.jsx
@@ -16,7 +16,7 @@ import {
 const MainHeader = styled(LooseRowSpacedAlignTop)`
   border-bottom: 1.5px solid ${th('color.gray80')};
   line-height: 22px;
-  padding: ${grid(2)} ${grid(3)};
+  padding: ${grid(4)} ${grid(6)};
   z-index: 10000;
 `
 
@@ -76,13 +76,13 @@ const ButtonPanel = styled.div`
   flex-direction: row;
   font-size: 15px;
   justify-content: space-between;
-  padding: ${grid(1.5)} ${grid(3)};
+  padding: ${grid(3)} ${grid(6)};
   width: 100%;
 `
 
 const ButtonContainer = styled.div`
   display: flex;
-  gap: ${grid(2)};
+  gap: ${grid(4)};
 `
 
 const PrimaryActionButton = styled(ActionButton)`
@@ -111,7 +111,7 @@ const CheckBoxContainer = styled.div`
 const ModalContainer = styled.div`
   flex: 1 1 100%;
   overflow-y: auto;
-  padding: ${grid(2.5)} ${grid(3)};
+  padding: ${grid(5)} ${grid(6)};
   position: relative;
   width: 100%;
 `

--- a/packages/client/app/components/component-notification-event/components/CustomInputs.jsx
+++ b/packages/client/app/components/component-notification-event/components/CustomInputs.jsx
@@ -9,6 +9,7 @@ import Creatable from 'react-select/creatable'
 import { ThemeContext } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { Minus, Plus } from 'react-feather'
+import { grid } from '@coko/client'
 
 import { useNumber } from '../../../hooks/dataTypeHooks'
 import { Col, CounterInputWrapper, InputWrapper, Row } from '../misc/styleds'
@@ -46,7 +47,7 @@ const styles = theme => ({
       boxShadow: `1px solid ${theme.color.gray70}`,
     },
     fontSize: theme.fontSizeBaseSmall,
-    minHeight: `calc(${theme.gridUnit} * 5)`,
+    minHeight: grid(10)({ theme }),
     div: {
       color: theme.color.gray20,
     },

--- a/packages/client/app/components/component-notification-event/components/EditSection.jsx
+++ b/packages/client/app/components/component-notification-event/components/EditSection.jsx
@@ -54,17 +54,17 @@ const TwoColumnRow = styled(Row)`
   display: grid;
   gap: 8px 16px;
   grid-template-columns: repeat(2, 1fr);
-  padding-inline: ${grid(3)};
+  padding-inline: ${grid(6)};
 `
 
 const EventSettings = styled(TwoColumnRow)`
   border-bottom: 1px solid #ddd;
-  gap: ${grid(2)} ${grid(2)};
-  padding: 0 ${grid(3)} ${grid(5)};
+  gap: ${grid(4)} ${grid(4)};
+  padding: 0 ${grid(6)} ${grid(10)};
 `
 
 const EmailSettings = styled(Col)`
-  gap: ${grid(2)};
+  gap: ${grid(4)};
   justify-content: flex-start;
   max-height: 330px;
   min-height: 300px;

--- a/packages/client/app/components/component-notification-event/components/EventContent.jsx
+++ b/packages/client/app/components/component-notification-event/components/EventContent.jsx
@@ -18,7 +18,7 @@ const Header = styled.header`
   border-bottom: 1px solid #ddd;
   display: flex;
   justify-content: space-between;
-  padding: ${grid(2)} ${grid(3)};
+  padding: ${grid(4)} ${grid(6)};
 
   > :first-child {
     gap: 4px;

--- a/packages/client/app/components/component-notification-event/components/EventsList.jsx
+++ b/packages/client/app/components/component-notification-event/components/EventsList.jsx
@@ -40,7 +40,7 @@ const StyledListHeader = styled(ListHeader)`
   color: var(--color-1);
   opacity: ${p => (p.$active ? 1 : 0.8)};
   overflow: hidden;
-  padding-block: ${grid(1)};
+  padding-block: ${grid(2)};
 
   p {
     font-size: 14px;
@@ -61,7 +61,7 @@ const EventSource = styled.div`
   color: var(--color-1);
   display: flex;
   justify-content: space-between;
-  padding: 0 ${grid(0.5)};
+  padding: 0 ${grid(1)};
   width: 100%;
 `
 
@@ -101,7 +101,7 @@ const Actions = styled(ActionsContainer)`
   align-items: center;
   gap: 0;
   justify-content: center;
-  padding-inline: ${grid(1.5)};
+  padding-inline: ${grid(3)};
 
   svg {
     aspect-ratio: 1 / 1;
@@ -115,7 +115,7 @@ const StyledListItem = styled(OptionListItem)`
   background: ${p => (!p.$selected ? '#fbfbfb' : '#fff')};
   border-color: #ddd;
   /* border-left-color: ${p => (!p.$selected ? '#ccc' : 'transparent')}; */
-  padding: ${grid(1.5)} ${grid(2.5)};
+  padding: ${grid(3)} ${grid(5)};
 `
 
 const ActionButton = styled(ActionIcon)`

--- a/packages/client/app/components/component-notification-event/misc/styleds.jsx
+++ b/packages/client/app/components/component-notification-event/misc/styleds.jsx
@@ -13,7 +13,7 @@ export const EventEditForm = styled.form`
   gap: 0;
   height: 100%;
   overflow: hidden;
-  padding: ${grid(2)} ${grid(6)} ${grid(3)};
+  padding: ${grid(4)} ${grid(12)} ${grid(6)};
   width: 100%;
 
   h3,
@@ -27,7 +27,7 @@ export const EventEditForm = styled.form`
 `
 
 export const Row = styled(FlexRow)`
-  gap: ${grid(2)};
+  gap: ${grid(4)};
   width: 100%;
 `
 
@@ -53,7 +53,7 @@ export const EditSection = styled(Col)`
   max-height: ${p => (p.$collapsed ? '0' : '100%')};
   min-height: 0;
   overflow: auto;
-  padding: 0 ${grid(4)};
+  padding: 0 ${grid(8)};
   transition: all 0.3s;
 
   small {
@@ -75,19 +75,19 @@ export const EditSection = styled(Col)`
 
   small,
   strong {
-    padding: 0 ${grid(0.5)};
+    padding: 0 ${grid(1)};
   }
 
   h4 {
     margin: 0;
-    padding: ${grid(3)} ${grid(0.5)} ${grid(2)};
+    padding: ${grid(6)} ${grid(1)} ${grid(4)};
   }
 `
 
 export const TextInput = styled(StyledInput)`
   /* stylelint-disable-next-line declaration-no-important */
   border-color: ${p => p.$color} !important;
-  padding: ${grid(1.25)};
+  padding: ${grid(2.5)};
 `
 
 export const Header = styled(Row)`
@@ -95,7 +95,7 @@ export const Header = styled(Row)`
   border-bottom: 1px solid #ddd;
   color: ${th('color.brand1.base')};
   height: var(--header-height, 0);
-  padding: 0 ${grid(4)};
+  padding: 0 ${grid(8)};
 
   h3 {
     margin: 0;
@@ -112,7 +112,7 @@ export const ActionIcon = styled(CleanButton)`
   border: 1px solid ${p => p.$color || p.theme.color.brand1.base};
   border-radius: ${th('borderRadius')};
   filter: ${p => (p.$disabled ? 'grayscale(1)' : 'none')};
-  padding: ${grid(1)};
+  padding: ${grid(2)};
 
   svg {
     aspect-ratio: 1 / 1;
@@ -175,7 +175,7 @@ export const InputWrapper = styled.div`
 
   small {
     border-right: 1px solid #aaa;
-    padding: 3px ${grid(1)};
+    padding: 3px ${grid(2)};
     width: fit-content;
   }
 `

--- a/packages/client/app/components/component-production/src/components/PreviousFeedbackSubmissions.jsx
+++ b/packages/client/app/components/component-production/src/components/PreviousFeedbackSubmissions.jsx
@@ -11,8 +11,8 @@ const Info = styled.div`
   border-radius: ${th('borderRadius')};
   color: ${th('color.gray5')};
   font-size: ${th('fontSizeBase')};
-  margin: ${grid(3)};
-  padding: ${grid(2)} ${grid(2)};
+  margin: ${grid(6)};
+  padding: ${grid(4)} ${grid(4)};
 `
 
 const PreviousFeedbackSubmissions = ({ version }) => {

--- a/packages/client/app/components/component-production/src/components/Production.jsx
+++ b/packages/client/app/components/component-production/src/components/Production.jsx
@@ -38,12 +38,12 @@ import VerifyPayloadModal from './VerifyPayloadModal/VerifyPayloadModal'
 const useVersioning = true
 
 const PreviousFeedBackSection = styled.div`
-  margin-bottom: calc(${th('gridUnit')} * 3);
+  margin-bottom: ${grid(6)};
 `
 
 const TabsRow = styled.div`
   display: flex;
-  margin-top: ${grid(1)};
+  margin-top: ${grid(2)};
 `
 
 const TabRow = styled(FlexRow)`
@@ -52,7 +52,7 @@ const TabRow = styled(FlexRow)`
 
 const RightControls = styled(ControlsContainer)`
   margin-left: auto;
-  margin-bottom: ${grid(1)};
+  margin-bottom: ${grid(2)};
 `
 
 const FormTemplateStyled = styled.div`

--- a/packages/client/app/components/component-production/src/components/VerifyPayloadModal/VerifyPayloadModal.jsx
+++ b/packages/client/app/components/component-production/src/components/VerifyPayloadModal/VerifyPayloadModal.jsx
@@ -108,7 +108,7 @@ const Header = styled(FlexRow)`
   align-items: center;
   background: ${th('color.brand1.base')};
   justify-content: space-between;
-  padding: ${grid(0.6)} ${grid(1)};
+  padding: ${grid(1.2)} ${grid(2)};
   text-transform: uppercase;
   width: 100%;
 
@@ -116,7 +116,7 @@ const Header = styled(FlexRow)`
     color: ${th('colorBackground')};
     font-weight: bold;
     line-height: 1;
-    padding-left: ${grid(0.6)};
+    padding-left: ${grid(1.2)};
   }
 `
 
@@ -158,15 +158,15 @@ const ContentWrapper = styled.div`
 
 const FlexColCentered = styled(FlexCol)`
   align-items: center;
-  gap: ${grid(2)};
+  gap: ${grid(4)};
   justify-content: center;
 `
 
 const CheckApiButton = styled(CleanButton)`
   border: 1px solid #ddd;
-  border-radius: ${grid(1.2)};
+  border-radius: ${grid(2.4)};
   height: 200px;
-  padding: ${grid(1.2)};
+  padding: ${grid(2.4)};
   width: 200px;
 
   * {
@@ -181,7 +181,7 @@ const ResultHeader = styled(FlexRow)`
   font-weight: 700;
   justify-content: space-between;
   opacity: ${p => (p.$show ? 1 : 0)};
-  padding: ${grid(0.6)} 12px;
+  padding: ${grid(1.2)} 12px;
   width: 100%;
 
   p {
@@ -191,7 +191,7 @@ const ResultHeader = styled(FlexRow)`
 `
 
 const ResultHeaderActions = styled(FlexRow)`
-  gap: ${grid(1.2)};
+  gap: ${grid(2.4)};
   justify-content: space-between;
 
   a {
@@ -220,16 +220,16 @@ const LoadingWindow = styled(FlexColCentered)`
 const ErrorsList = styled.ul`
   display: flex;
   flex-direction: column;
-  gap: ${grid(0.6)};
+  gap: ${grid(1.2)};
   height: 100%;
   list-style-type: none;
-  padding: ${grid(0.6)};
+  padding: ${grid(1.2)};
 
   > li {
     background: ${th('colorBackground')};
     border: 1px solid #ddd;
     border-left: ${th('color.error.base')} 5px solid;
-    padding: ${grid(0.6)} ${grid(1.2)};
+    padding: ${grid(1.2)} ${grid(2.4)};
   }
 `
 // #endregion styled-components ----------------------------------------------------------------------------

--- a/packages/client/app/components/component-production/src/components/styles.jsx
+++ b/packages/client/app/components/component-production/src/components/styles.jsx
@@ -120,7 +120,7 @@ export const StyledFileRow = styled.div`
   align-items: center;
   background-color: ${th('color.backgroundA')};
   border-top: 1px solid ${th('color.gray90')};
-  column-gap: ${grid(2)};
+  column-gap: ${grid(4)};
   display: flex;
   flex-direction: row;
   line-height: 1.4em;
@@ -129,11 +129,11 @@ export const StyledFileRow = styled.div`
 
   &:first-child {
     border-top: none;
-    padding: ${grid(0.5)} ${grid(2)};
+    padding: ${grid(1)} ${grid(4)};
   }
 
   &:not(:first-child) {
-    padding: ${grid(1.5)} ${grid(2)};
+    padding: ${grid(3)} ${grid(4)};
   }
 `
 

--- a/packages/client/app/components/component-production/src/components/uploadManager/UploadAsset.jsx
+++ b/packages/client/app/components/component-production/src/components/uploadManager/UploadAsset.jsx
@@ -44,7 +44,7 @@ export const FilesHeading = styled.div`
   align-items: center;
   background-color: ${th('color.backgroundA')};
   border-top: 1px solid ${th('color.gray90')};
-  column-gap: ${grid(2)};
+  column-gap: ${grid(4)};
   display: flex;
   flex-direction: row;
   line-height: 1.4em;
@@ -53,11 +53,11 @@ export const FilesHeading = styled.div`
 
   &:first-child {
     border-top: none;
-    padding: ${grid(0.5)} ${grid(2)};
+    padding: ${grid(1)} ${grid(4)};
   }
 
   &:not(:first-child) {
-    padding: ${grid(1.5)} ${grid(2)};
+    padding: ${grid(3)} ${grid(4)};
   }
 `
 

--- a/packages/client/app/components/component-production/src/components/uploadManager/UploadComponent.jsx
+++ b/packages/client/app/components/component-production/src/components/uploadManager/UploadComponent.jsx
@@ -16,7 +16,7 @@ const Message = styled.div`
   width: 100%;
 
   svg {
-    margin-left: ${grid(1)};
+    margin-left: ${grid(2)};
   }
 `
 

--- a/packages/client/app/components/component-profile/src/ChangeEmail.jsx
+++ b/packages/client/app/components/component-profile/src/ChangeEmail.jsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import { th } from '@coko/client'
+import { grid } from '@coko/client'
 import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { TextField, Button } from '../../pubsweet'
@@ -12,7 +12,7 @@ import { TextField, Button } from '../../pubsweet'
 const InlineTextField = styled(TextField)`
   border-color: ${props => (props.$error ? '#ff2d1a' : '#AAA')};
   display: inline;
-  width: calc(${th('gridUnit')} * 24);
+  width: ${grid(48)};
 `
 
 const UpdateEmailError = styled.p`

--- a/packages/client/app/components/component-profile/src/ChangeUsername.jsx
+++ b/packages/client/app/components/component-profile/src/ChangeUsername.jsx
@@ -2,14 +2,14 @@
 
 import { useState } from 'react'
 import PropTypes from 'prop-types'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { TextField, Button } from '../../pubsweet'
 
 const InlineTextField = styled(TextField)`
   display: inline;
-  width: calc(${th('gridUnit')} * 24);
+  width: ${grid(48)};
 `
 
 const Container = styled.div`

--- a/packages/client/app/components/component-profile/src/Profile.jsx
+++ b/packages/client/app/components/component-profile/src/Profile.jsx
@@ -27,18 +27,18 @@ import { getLanguages } from '../../../i18n'
 const VersionText = styled.div`
   color: #757575;
   position: fixed;
-  bottom: ${grid(2)};
-  right: ${grid(3)};
+  bottom: ${grid(4)};
+  right: ${grid(6)};
 `
 
 const RolesRow = styled.div`
   display: flex;
   align-items: end;
-  margin-bottom: ${grid(1)};
+  margin-bottom: ${grid(2)};
 `
 
 const StyledCheckbox = styled(Checkbox)`
-  padding: ${grid(2)} ${grid(3)};
+  padding: ${grid(4)} ${grid(6)};
 `
 
 const SpecialRolesLabel = styled.div`

--- a/packages/client/app/components/component-profile/src/ProfileImage.jsx
+++ b/packages/client/app/components/component-profile/src/ProfileImage.jsx
@@ -1,16 +1,16 @@
-import { th } from '@coko/client'
+import { grid } from '@coko/client'
 import styled from 'styled-components'
 
 export const BigProfileImage = styled.img`
   border-radius: 50%;
-  height: calc(${th('gridUnit')} * 6);
+  height: ${grid(12)};
   object-fit: cover;
-  width: calc(${th('gridUnit')} * 6);
+  width: ${grid(12)};
 `
 
 export const SmallProfileImage = styled.img`
   border-radius: 50%;
-  height: calc(${th('gridUnit')} * 4);
+  height: ${grid(8)};
   object-fit: cover;
-  width: calc(${th('gridUnit')} * 4);
+  width: ${grid(8)};
 `

--- a/packages/client/app/components/component-published-artifact/components/ArticleArtifactPage.jsx
+++ b/packages/client/app/components/component-published-artifact/components/ArticleArtifactPage.jsx
@@ -18,15 +18,15 @@ const Container = styled.div`
   background: ${th('color.gray97')};
   border: 1px solid ${th('color.brand1.shade25')};
   border-radius: ${th('borderRadius')};
-  margin: ${grid(3.75)} auto;
+  margin: ${grid(7.5)} auto;
   max-width: 1000px;
-  padding: ${grid(5.625)} ${grid(7.5)} ${grid(7.5)} ${grid(7.5)};
+  padding: ${grid(11.25)} ${grid(15)} ${grid(15)} ${grid(15)};
   width: 90%;
 
   & > h1 {
     color: ${th('color.brand1.shade25')};
     font-size: 180%;
-    margin: ${grid(0.9375)} 0 ${grid(1.875)} 0;
+    margin: ${grid(1.875)} 0 ${grid(3.75)} 0;
   }
 `
 

--- a/packages/client/app/components/component-reporting/src/CardCollection.jsx
+++ b/packages/client/app/components/component-reporting/src/CardCollection.jsx
@@ -5,8 +5,8 @@ export const Card = styled.div`
   background-color: ${th('colorBackground')};
   border: 1px solid ${th('colorFurniture')};
   flex: 1 0 auto;
-  margin: ${grid(1)};
-  padding: ${grid(1)};
+  margin: ${grid(2)};
+  padding: ${grid(2)};
 `
 
 const CardCollection = styled.div`

--- a/packages/client/app/components/component-reporting/src/Tooltip.jsx
+++ b/packages/client/app/components/component-reporting/src/Tooltip.jsx
@@ -38,7 +38,7 @@ const Tip = styled.div`
 const TipInner = styled.div`
   background-color: ${th('colorFurniture')};
   border: 1px solid ${th('colorBorder')};
-  padding: ${grid(0.25)} ${grid(1)};
+  padding: ${grid(0.5)} ${grid(2)};
 `
 
 const Tooltip = ({ content, className }) => {

--- a/packages/client/app/components/component-review/src/components/DeclinedReviewer.jsx
+++ b/packages/client/app/components/component-review/src/components/DeclinedReviewer.jsx
@@ -4,7 +4,7 @@
 
 import { useState } from 'react'
 import styled from 'styled-components'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 import { Mail } from 'react-feather'
 import { useTranslation } from 'react-i18next'
 import { Primary, Secondary } from '../../../shared'
@@ -40,12 +40,12 @@ const EmailDisplay = styled(Secondary)`
   align-items: center;
   color: ${th('color.brand2.base')};
   display: flex;
-  margin-left: calc(${th('gridUnit')} * 2);
+  margin-left: ${grid(4)};
 `
 
 const MailIcon = styled(Mail)`
   height: ${th('fontSizeBase')};
-  margin-right: calc(${th('gridUnit')} / 2);
+  margin-right: ${grid(1)};
   width: auto;
 `
 

--- a/packages/client/app/components/component-review/src/components/Publish.jsx
+++ b/packages/client/app/components/component-review/src/components/Publish.jsx
@@ -50,15 +50,15 @@ const PublishButton = styled(Button)`
 
 const PublishWrapper = styled.div`
   div {
-    margin-bottom: ${grid(2)};
+    margin-bottom: ${grid(4)};
   }
 `
 
 const AdaStatusWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${grid(2)};
-  margin-bottom: ${grid(2)};
+  gap: ${grid(4)};
+  margin-bottom: ${grid(4)};
 `
 
 const Publish = ({

--- a/packages/client/app/components/component-review/src/components/coar/CoarMessages.jsx
+++ b/packages/client/app/components/component-review/src/components/coar/CoarMessages.jsx
@@ -20,27 +20,27 @@ const Container = styled.div`
   align-items: center;
   display: flex;
   flex-direction: column;
-  gap: ${grid(2)};
-  padding: ${grid(4)} 0;
+  gap: ${grid(4)};
+  padding: ${grid(8)} 0;
 `
 
 const MessageWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: ${grid(1)};
+  gap: ${grid(2)};
 `
 
 const CodeWrapper = styled.div`
   background-color: #ddd;
   border: 1px solid black;
   border-radius: ${th('borderRadius')};
-  padding: ${grid(2)};
+  padding: ${grid(4)};
 `
 
 const FlexRowItem = styled.div`
   display: flex;
   align-items: center;
-  gap: ${grid(2)};
+  gap: ${grid(4)};
 `
 
 const patterns = [

--- a/packages/client/app/components/component-review/src/components/decision/DecisionReview.jsx
+++ b/packages/client/app/components/component-review/src/components/decision/DecisionReview.jsx
@@ -4,14 +4,14 @@ import { useContext, useState } from 'react'
 import { isObject, find } from 'lodash'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { th } from '@coko/client'
+import { grid } from '@coko/client'
 import { JournalContext } from '../../../../xpub-journal'
 import { ensureJsonIsParsed } from '../../../../../shared/objectUtils'
 import ReviewHeading from './ReviewHeading'
 import ReviewDetailsModal from '../../../../component-review-detail-modal/src'
 
 const Root = styled.div`
-  margin-bottom: calc(${th('gridUnit')} * 3);
+  margin-bottom: ${grid(6)};
 `
 
 const DecisionReview = ({

--- a/packages/client/app/components/component-review/src/components/decision/InvitationResults.jsx
+++ b/packages/client/app/components/component-review/src/components/decision/InvitationResults.jsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import { th } from '@coko/client'
+import { grid } from '@coko/client'
 import { useTranslation } from 'react-i18next'
 import { Button } from '../../../../pubsweet'
 import { SectionRow } from '../style'
@@ -61,7 +61,7 @@ export const Ordinal = styled.span`
 `
 
 const Root = styled.div`
-  margin-bottom: calc(${th('gridUnit')} * 3);
+  margin-bottom: ${grid(6)};
 `
 
 const ResponseComment = styled.div`

--- a/packages/client/app/components/component-review/src/components/emailNotifications/index.jsx
+++ b/packages/client/app/components/component-review/src/components/emailNotifications/index.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 
 import { useState, useContext } from 'react'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 import styled, { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { SectionHeader, SectionRowGrid, Title } from '../style'
@@ -50,7 +50,7 @@ export const EmailErrorMessageWrapper = styled.div`
   padding: calc(8px * 2) calc(8px * 3);
 
   &:not(:last-child) {
-    margin-bottom: ${th('gridUnit')};
+    margin-bottom: ${grid(2)};
   }
 `
 

--- a/packages/client/app/components/component-review/src/components/reviewPreview/ReviewPreview.jsx
+++ b/packages/client/app/components/component-review/src/components/reviewPreview/ReviewPreview.jsx
@@ -19,7 +19,7 @@ const Page = styled.div`
   background: ${th('color.backgroundC')};
   height: 100vh;
   overflow-y: scroll;
-  padding: ${grid(2)};
+  padding: ${grid(4)};
   width: 100%;
 `
 
@@ -29,7 +29,7 @@ const IconLink = styled.div`
   cursor: pointer;
   display: flex;
   flex-direction: row;
-  margin: ${grid(2)};
+  margin: ${grid(4)};
   width: fit-content;
 `
 

--- a/packages/client/app/components/component-review/src/components/reviewers/InviteReviewerModal.jsx
+++ b/packages/client/app/components/component-review/src/components/reviewers/InviteReviewerModal.jsx
@@ -23,7 +23,7 @@ import { selectReviewerInvitationEmail } from './util'
 
 const ModalContainer = styled(LooseColumn)`
   background-color: ${th('colorBackground')};
-  padding: ${grid(2.5)} ${grid(3)};
+  padding: ${grid(5)} ${grid(6)};
   z-index: 10000;
 `
 

--- a/packages/client/app/components/component-review/src/components/reviewers/KanbanCard.jsx
+++ b/packages/client/app/components/component-review/src/components/reviewers/KanbanCard.jsx
@@ -24,7 +24,7 @@ const Card = styled.div.attrs({
   flex-direction: row;
   font-size: ${th('fontSizeBaseSmall')};
   justify-content: space-between;
-  padding: ${grid(1)};
+  padding: ${grid(2)};
   position: relative;
   width: 100%;
 
@@ -40,7 +40,7 @@ const InfoGrid = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin-left: ${grid(1)};
+  margin-left: ${grid(2)};
 `
 
 const NameDisplay = styled.div`
@@ -66,12 +66,12 @@ const EmailDisplay = styled(DateDisplay)`
       ? props.theme.colorError
       : props.theme.color.brand1.base};
   display: flex;
-  margin-top: calc(${th('gridUnit')} / 2);
+  margin-top: ${grid(1)};
 `
 
 const MailIcon = styled(Mail)`
   height: 12px;
-  margin-right: calc(${th('gridUnit')} / 2);
+  margin-right: ${grid(1)};
   width: auto;
 `
 

--- a/packages/client/app/components/component-review/src/components/reviewers/Reviewer.jsx
+++ b/packages/client/app/components/component-review/src/components/reviewers/Reviewer.jsx
@@ -3,13 +3,13 @@
 import styled from 'styled-components'
 // import { map } from 'lodash'
 // import Moment from 'react-moment'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 import { Avatar } from '../../../../pubsweet'
 
 const Root = styled.div`
   font-family: ${th('fontReviewer')};
-  margin-right: ${th('gridUnit')};
-  padding: ${th('gridUnit')};
+  margin-right: ${grid(2)};
+  padding: ${grid(2)};
 `
 
 const ordinalLetter = ordinal =>

--- a/packages/client/app/components/component-review/src/components/reviewers/ReviewerForm.jsx
+++ b/packages/client/app/components/component-review/src/components/reviewers/ReviewerForm.jsx
@@ -20,7 +20,7 @@ const OptionRenderer = option => (
 
 const RowGridStyled = styled.div`
   display: grid;
-  gap: ${grid(2)};
+  gap: ${grid(4)};
   grid-template-columns: repeat(4, minmax(0, 1fr));
 `
 
@@ -79,7 +79,7 @@ const ReviewerForm = ({
           defaultChecked={false}
           label={t('decisionPage.New User')}
           onChange={() => setIsNewUser(!isNewUser)}
-          width={grid(0.75)}
+          width={grid(1.5)}
         />
         {isNewUser ? (
           <>

--- a/packages/client/app/components/component-review/src/components/style.jsx
+++ b/packages/client/app/components/component-review/src/components/style.jsx
@@ -4,7 +4,7 @@ import { Button } from '../../../pubsweet'
 import { RoundIconButton } from '../../../shared'
 
 export const AdminSection = styled.div`
-  margin-bottom: calc(${th('gridUnit')} * 3);
+  margin-bottom: ${grid(6)};
 `
 
 export const Roles = styled.div`
@@ -45,7 +45,7 @@ export const EditorWrapper = styled.div`
 
 export const FormStatus = styled.div`
   color: ${th('color.brand2.base')};
-  line-height: ${grid(5)};
+  line-height: ${grid(10)};
   text-align: center;
 `
 
@@ -53,7 +53,7 @@ export const ErrorWrap = styled.div`
   /* stylelint-disable selector-class-pattern */
 
   .ProseMirror {
-    margin-bottom: ${grid(4)};
+    margin-bottom: ${grid(8)};
   }
 
   ${({ error }) =>
@@ -63,8 +63,8 @@ export const ErrorWrap = styled.div`
         border-color: red;
       }
       ${ErrorText} {
-        margin-top: ${grid(-4)};
-        margin-bottom: ${grid(1)};
+        margin-top: ${grid(-8)};
+        margin-bottom: ${grid(2)};
       }
     `}
 
@@ -77,7 +77,7 @@ export const ErrorText = styled.div`
 `
 
 export const RecommendationInputContainer = styled.div`
-  line-height: ${grid(5)};
+  line-height: ${grid(10)};
 `
 
 export const StyledNotifyButton = styled(Button)`

--- a/packages/client/app/components/component-submit/src/components/AuthorsInput.jsx
+++ b/packages/client/app/components/component-submit/src/components/AuthorsInput.jsx
@@ -23,8 +23,8 @@ import useAuthorsFieldQueries from './hooks/useAuthorsInputQueries'
 const StyledButton = styled(Button)`
   cursor: pointer;
   display: flex;
-  gap: ${grid(1)};
-  margin-bottom: ${grid(2)};
+  gap: ${grid(2)};
+  margin-bottom: ${grid(4)};
 
   &[disabled] {
     cursor: not-allowed;
@@ -33,7 +33,7 @@ const StyledButton = styled(Button)`
 
 const Wrapper = styled.div`
   > div:not(:last-child) {
-    margin-bottom: ${grid(2)};
+    margin-bottom: ${grid(4)};
   }
 `
 
@@ -42,14 +42,14 @@ const AuthorContainer = styled.div`
   border-radius: ${th('borderRadius')};
   display: flex;
   ${({ fullWidth }) => (fullWidth ? 'width: 100%' : 'max-width: 1000px')};
-  padding: ${grid(2)};
+  padding: ${grid(4)};
 `
 
 const Author = styled.div`
   display: grid;
-  gap: ${grid(2)} ${grid(4)};
+  gap: ${grid(4)} ${grid(8)};
   grid-template-columns: repeat(2, 1fr);
-  padding: ${grid(1)};
+  padding: ${grid(2)};
   width: 100%;
 `
 
@@ -74,10 +74,10 @@ const StyledSelect = styled(Creatable)`
 
 const StyledDeleteControl = styled(DeleteControl)`
   background-color: ${th('colorBackground')};
-  height: ${grid(3)};
+  height: ${grid(6)};
   margin: 0;
-  padding-left: ${grid(1)};
-  width: ${grid(3)};
+  padding-left: ${grid(2)};
+  width: ${grid(6)};
 
   &:hover {
     background-color: ${th('colorBackground')};
@@ -90,7 +90,7 @@ const FieldLabel = styled(FlexRow)`
   display: flex;
   font-size: ${th('fontSizeBaseSmall')};
   justify-content: space-between;
-  padding-inline: ${grid(0.25)};
+  padding-inline: ${grid(0.5)};
 `
 // #endregion styled
 

--- a/packages/client/app/components/component-submit/src/components/Confirm.jsx
+++ b/packages/client/app/components/component-submit/src/components/Confirm.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { sanitize } from 'isomorphic-dompurify'
 import { unescape } from 'lodash'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 import { useTranslation } from 'react-i18next'
 import { PlainButton } from '../../../pubsweet'
 import { Heading1 } from '../style'
@@ -17,17 +17,17 @@ const Wrapper = styled.div`
   max-height: 100%;
   max-width: 60em;
   overflow-y: auto;
-  padding: calc(${th('gridUnit')} * 6);
+  padding: ${grid(12)};
 `
 
 const Paragraph = styled.p`
   font-size: ${th('fontSizeBase')};
-  margin-bottom: calc(${th('gridUnit')} * 3);
+  margin-bottom: ${grid(6)};
   width: 100%;
 `
 
 const Divider = styled.span`
-  margin: 0 ${th('gridUnit')};
+  margin: 0 ${grid(2)};
 `
 
 const createMarkup = encodedHtml => ({

--- a/packages/client/app/components/component-submit/src/components/FormTemplate.jsx
+++ b/packages/client/app/components/component-submit/src/components/FormTemplate.jsx
@@ -115,7 +115,7 @@ const SafeRadioGroup = styled(RadioGroup).attrs({
 const NoteRight = styled.div`
   font-size: ${th('fontSizeBaseSmall')};
   line-height: ${th('lineHeightBaseSmall')};
-  padding: ${grid(0.9375)} ${grid(1.875)};
+  padding: ${grid(1.875)} ${grid(3.75)};
   text-align: right;
 `
 

--- a/packages/client/app/components/component-submit/src/components/LocalContext.jsx
+++ b/packages/client/app/components/component-submit/src/components/LocalContext.jsx
@@ -34,9 +34,9 @@ const Input = styled.input`
 const StyledButton = styled(Button)`
   cursor: pointer;
   display: flex;
-  gap: ${grid(1)};
-  margin-bottom: ${grid(2)};
-  padding-left: ${grid(1)};
+  gap: ${grid(2)};
+  margin-bottom: ${grid(4)};
+  padding-left: ${grid(2)};
 
   &[disabled] {
     cursor: not-allowed;
@@ -46,7 +46,7 @@ const StyledButton = styled(Button)`
 const TitleLabel = styled.div`
   color: ${th('color.brand1.base')};
   font-size: 24px;
-  margin-bottom: ${grid(1)};
+  margin-bottom: ${grid(2)};
 `
 
 const NoProjectFound = styled.span`
@@ -58,14 +58,14 @@ const LocalContextResultContainer = styled.div`
   border: 1px solid ${th('color.brand1.base')};
   display: flex;
   flex-direction: column;
-  margin-bottom: ${grid(2)};
-  padding: ${grid(2)};
+  margin-bottom: ${grid(4)};
+  padding: ${grid(4)};
 `
 
 const ItemContainer = styled.div`
   display: flex;
   flex-direction: row;
-  margin-bottom: ${grid(1)};
+  margin-bottom: ${grid(2)};
 `
 
 const ItemTag = styled.span`

--- a/packages/client/app/components/component-submit/src/components/MultipleDoi.jsx
+++ b/packages/client/app/components/component-submit/src/components/MultipleDoi.jsx
@@ -14,8 +14,8 @@ const Doi = styled.div`
   display: grid;
   gap: 36px;
   grid-template-columns: 1fr 1fr;
-  margin-bottom: ${grid(1.875)};
-  margin-top: ${grid(0.9375)};
+  margin-bottom: ${grid(3.75)};
+  margin-top: ${grid(1.875)};
   position: relative;
   width: 600px;
 

--- a/packages/client/app/components/component-submit/src/components/UploadButton.jsx
+++ b/packages/client/app/components/component-submit/src/components/UploadButton.jsx
@@ -3,7 +3,7 @@
 /* eslint-disable no-return-assign */
 
 import styled from 'styled-components'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 
 const Button = styled.button.attrs(() => ({
   type: 'button',
@@ -11,9 +11,9 @@ const Button = styled.button.attrs(() => ({
   background: transparent;
   border: ${th('borderWidth')} dashed ${th('colorBorder')};
   cursor: pointer;
-  height: calc(${th('gridUnit')} * 3);
-  margin-bottom: calc(${th('gridUnit')} * 3);
-  padding: ${th('gridUnit')};
+  height: ${grid(6)};
+  margin-bottom: ${grid(6)};
+  padding: ${grid(2)};
 `
 
 const UploadButton = ({ name, buttonText, onChange }) => {

--- a/packages/client/app/components/component-submit/src/components/molecules/Accordion.jsx
+++ b/packages/client/app/components/component-submit/src/components/molecules/Accordion.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import styled from 'styled-components'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 import { Button } from '../../../../pubsweet'
 import { JournalContext } from '../../../../xpub-journal'
 
@@ -53,7 +53,7 @@ const AccordionHeading = ({
   const Root = styled.div`
     align-items: baseline;
     display: flex;
-    margin-bottom: calc(${th('gridUnit')} * 3);
+    margin-bottom: ${grid(6)};
   `
 
   const Ordinal = styled(Title)``

--- a/packages/client/app/components/component-submit/src/style.jsx
+++ b/packages/client/app/components/component-submit/src/style.jsx
@@ -6,7 +6,7 @@ export { Container, Content, Heading } from '../../shared'
 export const Heading1 = styled.h1`
   font-size: ${th('fontSizeHeading3')};
   line-height: ${th('lineHeightHeading3')};
-  margin: 0 0 calc(${th('gridUnit')} * 3);
+  margin: 0 0 ${grid(6)};
 `
 
 export const Section = styled.section.attrs(props => ({
@@ -20,13 +20,13 @@ export const Section = styled.section.attrs(props => ({
   /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
   flex-wrap: ${({ $cssOverrides }) => $cssOverrides?.wrap ?? 'nowrap'};
   justify-content: space-between;
-  margin: ${grid(3)} 0;
+  margin: ${grid(6)} 0;
 `
 
 export const Legend = styled.div`
   font-size: ${th('fontSizeBase')};
   font-weight: 500;
-  margin-bottom: ${grid(0.9375)};
+  margin-bottom: ${grid(1.875)};
 `
 
 export const SubNote = styled.span`
@@ -125,6 +125,6 @@ export const SubNote = styled.span`
 `
 
 export const UploadContainer = styled.div`
-  padding: ${grid(3)};
+  padding: ${grid(6)};
   text-align: center;
 `

--- a/packages/client/app/components/component-task-manager/src/Task.jsx
+++ b/packages/client/app/components/component-task-manager/src/Task.jsx
@@ -34,7 +34,7 @@ import CounterField from '../../shared/CounterField'
 const TaskRow = styled.div`
   align-items: flex-start;
   display: flex;
-  gap: ${grid('1')};
+  gap: ${grid('2')};
 
   &:hover > div:first-child > div:first-child > svg,
   &:hover > div:first-child > button:last-child > svg {
@@ -61,7 +61,7 @@ const TitleCell = styled.div`
 const StatusActionCell = styled.div`
   /* stylelint-disable-next-line declaration-no-important */
   background: none !important;
-  border-right: ${grid(1)} solid transparent;
+  border-right: ${grid(2)} solid transparent;
   flex: 0 1 12em;
   justify-content: flex-start;
 
@@ -72,7 +72,7 @@ const StatusActionCell = styled.div`
         `
       : ''}
 
-  padding-right: ${grid(1)};
+  padding-right: ${grid(2)};
 `
 
 const DurationDaysCell = styled.div`
@@ -87,10 +87,10 @@ const DurationDaysCell = styled.div`
 const Handle = styled.div`
   align-items: center;
   display: flex;
-  flex: 0 0 ${grid(3)};
-  height: ${grid(5)};
+  flex: 0 0 ${grid(6)};
+  height: ${grid(10)};
   justify-content: center;
-  width: ${grid(3)};
+  width: ${grid(6)};
 `
 
 const DragIcon = styled(DragVerticalIcon)`
@@ -116,7 +116,7 @@ const Ellipsis = styled(MoreVertical)`
 
 const ModalContainer = styled(LooseColumn)`
   background-color: ${th('color.backgroundA')};
-  padding: ${grid(2.5)} ${grid(3)};
+  padding: ${grid(5)} ${grid(6)};
   z-index: 10000;
 `
 
@@ -190,7 +190,7 @@ const DueDateFieldContainer = styled(BaseFieldContainer)`
   }
 
   > div + div {
-    margin-left: ${grid(1)};
+    margin-left: ${grid(2)};
   }
 `
 

--- a/packages/client/app/components/component-task-manager/src/TaskEditModal.jsx
+++ b/packages/client/app/components/component-task-manager/src/TaskEditModal.jsx
@@ -43,7 +43,7 @@ const TaskRecipientsContainer = styled.div`
 `
 
 const TaskSectionContainer = styled.div`
-  margin-bottom: ${grid(4)};
+  margin-bottom: ${grid(8)};
 
   &:first-child {
     padding-top: 0;
@@ -84,7 +84,7 @@ const AssigneeFieldContainer = styled(BaseFieldContainer)`
 `
 
 const DescriptionFieldContainer = styled(BaseFieldContainer)`
-  margin-top: ${grid(5)};
+  margin-top: ${grid(10)};
 
   & .wax-surface-scroll {
     height: 100px;

--- a/packages/client/app/components/pubsweet/Attachment.jsx
+++ b/packages/client/app/components/pubsweet/Attachment.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 
 import styled from 'styled-components'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 
 import Icon from './Icon'
 
@@ -18,7 +18,7 @@ const Filename = styled.span`
 `
 
 const IconContainer = styled.span`
-  margin: 0 ${th('gridUnit')};
+  margin: 0 ${grid(2)};
 
   svg {
     height: ${th('fontSizeBase')};

--- a/packages/client/app/components/pubsweet/Avatar.jsx
+++ b/packages/client/app/components/pubsweet/Avatar.jsx
@@ -2,7 +2,7 @@
 
 import styled from 'styled-components'
 
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 
 const statusColor = props =>
   ({
@@ -14,8 +14,8 @@ const Container = styled.svg.attrs(() => ({
   viewBox: '0 0 105 70',
   xmlns: 'http://www.w3.org/2000/svg',
 }))`
-  height: calc(${th('gridUnit')} * 6);
-  width: calc(${th('gridUnit')} * 9);
+  height: ${grid(12)};
+  width: ${grid(18)};
 `
 
 const Persona = styled.path.attrs(() => ({

--- a/packages/client/app/components/pubsweet/Button.jsx
+++ b/packages/client/app/components/pubsweet/Button.jsx
@@ -12,9 +12,9 @@ const StyledButton = styled.button.attrs(props => ({
   cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
   font-family: ${th('fontInterface')};
   font-size: ${th('fontSizeBase')};
-  line-height: ${grid(3)};
-  min-width: ${grid(12)};
-  padding: ${grid(1)};
+  line-height: ${grid(6)};
+  min-width: ${grid(24)};
+  padding: ${grid(2)};
 
   &:focus,
   &:hover {

--- a/packages/client/app/components/pubsweet/Checkbox.jsx
+++ b/packages/client/app/components/pubsweet/Checkbox.jsx
@@ -1,14 +1,14 @@
 /* eslint-disable react/prop-types */
 
 import styled from 'styled-components'
-import { th, override } from '@coko/client'
+import { grid, th, override } from '@coko/client'
 
 const Label = styled.span`
   ${override('ui.Checkbox.Label')};
 `
 
 const Input = styled.input`
-  margin-right: ${th('gridUnit')};
+  margin-right: ${grid(2)};
   ${override('ui.Checkbox.Input')};
 `
 
@@ -19,7 +19,7 @@ const Root = styled.label`
   font-family: ${th('fontAuthor')};
 
   &:not(:last-child) {
-    margin-right: ${props => (props.inline ? props.theme.gridUnit : '0')};
+    margin-right: ${props => (props.inline ? grid(2)(props) : '0')};
   }
 
   ${override('ui.Checkbox')};

--- a/packages/client/app/components/pubsweet/Dropdown.jsx
+++ b/packages/client/app/components/pubsweet/Dropdown.jsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { override, th } from '@coko/client'
+import { grid, override, th } from '@coko/client'
 
 import UIButton from './Button'
 import UIIcon from './Icon'
@@ -56,7 +56,7 @@ const DropdownMenu = styled.ul`
   font-family: ${th('fontInterface')};
   font-size: ${th('fontSizeBase')};
   list-style-type: none;
-  margin: calc(${th('gridUnit')} / 4) 0 0 0;
+  margin: ${grid(0.5)} 0 0 0;
   padding: 0;
   position: absolute;
   top: ${props => (props.direction === 'down' ? '100%' : '-')};
@@ -70,7 +70,7 @@ const Item = styled.li`
   cursor: pointer;
   font-family: ${th('fontInterface')};
   font-size: ${th('fontSizeBase')};
-  padding: ${th('gridUnit')};
+  padding: ${grid(2)};
   white-space: normal;
   overflow-wrap: break-word;
 

--- a/packages/client/app/components/pubsweet/Icon.jsx
+++ b/packages/client/app/components/pubsweet/Icon.jsx
@@ -6,18 +6,18 @@ import get from 'lodash/get'
 import * as icons from 'react-feather'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import { th, override } from '@coko/client'
+import { grid, override } from '@coko/client'
 
 import Colorize from './Colorize'
 
 const Container = styled.span`
   display: inline-flex;
-  padding: calc(${th('gridUnit')} / 2);
+  padding: ${grid(1)};
 
   svg {
-    height: calc(${props => props.size} * ${th('gridUnit')});
+    height: ${props => grid(props.size * 2)(props)};
     stroke: ${props => props.color || props.theme.colorText};
-    width: calc(${props => props.size} * ${th('gridUnit')});
+    width: ${props => grid(props.size * 2)(props)};
   }
 
   /* stylelint-disable-next-line order/properties-alphabetical-order */

--- a/packages/client/app/components/pubsweet/Radio.jsx
+++ b/packages/client/app/components/pubsweet/Radio.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 
 import styled, { css } from 'styled-components'
-import { th, override } from '@coko/client'
+import { grid, override } from '@coko/client'
 
 const Label = styled.span`
   ${props =>
@@ -15,7 +15,7 @@ const Label = styled.span`
 `
 
 const Input = styled.input`
-  margin-right: ${th('gridUnit')};
+  margin-right: ${grid(2)};
   ${override('ui.Radio.Input')};
 `
 
@@ -24,7 +24,7 @@ const Root = styled.label`
   color: ${props => (props.color ? props.color : props.theme.colorText)};
   cursor: pointer;
   display: ${props => (props.$inline ? 'inline-flex' : 'flex')};
-  min-height: calc(${th('gridUnit')} * 3);
+  min-height: ${grid(6)};
 
   ${override('ui.Radio')};
 `

--- a/packages/client/app/components/pubsweet/Select.jsx
+++ b/packages/client/app/components/pubsweet/Select.jsx
@@ -2,6 +2,7 @@
 
 import Select from 'react-select'
 import { withTheme } from 'styled-components'
+import { grid } from '@coko/client'
 
 const StyledSelect = props => {
   const { theme, ...rest } = props
@@ -18,7 +19,6 @@ const StyledSelect = props => {
     colorTextReverse,
     fontInterface,
     fontSizeBase,
-    gridUnit,
     lineHeightBase,
   } = theme
 
@@ -39,7 +39,7 @@ const StyledSelect = props => {
         fontFamily: fontInterface,
         fontSize: fontSizeBase,
         lineHeight: lineHeightBase,
-        padding: gridUnit,
+        padding: grid(2)({ theme }),
       }
 
       if (state.isFocused) {
@@ -65,7 +65,6 @@ const StyledSelect = props => {
       borderRadius: 0,
       boxShadow: 'none',
       flex: '0 1 100%',
-      marginTop: gridUnit / 4,
     }),
     menuList: base => ({
       ...base,

--- a/packages/client/app/components/pubsweet/TextArea.jsx
+++ b/packages/client/app/components/pubsweet/TextArea.jsx
@@ -2,7 +2,7 @@
 
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import { th, override, validationColor } from '@coko/client'
+import { grid, th, override, validationColor } from '@coko/client'
 import { useUID } from 'react-uid'
 
 const Root = styled.div`
@@ -29,7 +29,7 @@ const Area = styled.textarea`
   font-size: ${th('fontSizeBase')};
   line-height: ${th('lineHeightBase')};
   max-width: 100%;
-  padding: calc(${th('gridUnit')} * 1.5) ${th('gridUnit')};
+  padding: ${grid(3)} ${grid(2)};
 
   &::placeholder {
     color: ${th('colorTextPlaceholder')};

--- a/packages/client/app/components/pubsweet/TextField.jsx
+++ b/packages/client/app/components/pubsweet/TextField.jsx
@@ -1,14 +1,13 @@
 /* eslint-disable react/prop-types */
 
 import styled from 'styled-components'
-import { th, override, validationColor } from '@coko/client'
+import { grid, th, override, validationColor } from '@coko/client'
 import { useUID } from 'react-uid'
 
 const Root = styled.div`
   display: flex;
   flex-direction: column;
-  margin-bottom: ${props =>
-    props.$inline ? '0' : `calc(${props.theme.gridUnit} * 3)`};
+  margin-bottom: ${props => (props.$inline ? '0' : grid(6)(props))};
   ${override('ui.TextField')};
 `
 
@@ -25,8 +24,8 @@ const Input = styled.input`
   border-radius: ${th('borderRadius')};
   font-family: inherit;
   font-size: inherit;
-  height: calc(${th('gridUnit')} * 6);
-  padding: 0 ${th('gridUnit')};
+  height: ${grid(12)};
+  padding: 0 ${grid(2)};
 
   &::placeholder {
     color: ${th('colorTextPlaceholder')};

--- a/packages/client/app/components/pubsweet/ValidatedFieldFormik.jsx
+++ b/packages/client/app/components/pubsweet/ValidatedFieldFormik.jsx
@@ -3,7 +3,7 @@
 import { FastField } from 'formik'
 import { get } from 'lodash'
 import styled from 'styled-components'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 
 // TODO: pass ...props.input to children automatically?
 
@@ -14,7 +14,7 @@ const MessageWrapper = styled.div`
 
 const Message = styled.div`
   &:not(:last-child) {
-    margin-bottom: ${th('gridUnit')};
+    margin-bottom: ${grid(2)};
   }
   font-size: ${th('fontSizeBaseSmall')};
   line-height: ${th('lineHeightBaseSmall')};

--- a/packages/client/app/components/shared/Accordion.jsx
+++ b/packages/client/app/components/shared/Accordion.jsx
@@ -13,7 +13,7 @@ const AccordionHead = styled(MinimalButton)`
 `
 
 const AccordionBody = styled.div`
-  padding: 0 ${grid(1)} ${grid(2)} ${grid(4)};
+  padding: 0 ${grid(2)} ${grid(4)} ${grid(8)};
   width: 100%;
 `
 

--- a/packages/client/app/components/shared/Action.jsx
+++ b/packages/client/app/components/shared/Action.jsx
@@ -15,7 +15,7 @@ const ActionLink = styled.button`
   display: inline-flex;
   flex-direction: row;
   font-size: inherit;
-  gap: ${grid(0.625)};
+  gap: ${grid(1.25)};
   line-height: inherit;
   opacity: ${({ disabled }) => (disabled ? '0.5' : '1')};
   width: fit-content;
@@ -46,14 +46,14 @@ const Spinner = styled.div`
     /* stylelint-disable-next-line string-quotes */
     content: '';
     display: block;
-    height: ${grid(2)};
-    width: ${grid(2)};
+    height: ${grid(4)};
+    width: ${grid(4)};
   }
 `
 
 const IconContainer = styled.div`
-  height: ${grid(2)};
-  width: ${grid(2)};
+  height: ${grid(4)};
+  width: ${grid(4)};
 `
 
 /** Equivalent of <a href="...">, styled the same as other Actions */

--- a/packages/client/app/components/shared/ActionButton.jsx
+++ b/packages/client/app/components/shared/ActionButton.jsx
@@ -15,8 +15,8 @@ const BaseButton = styled.button`
   font-size: ${th('fontSizeBase')};
   font-weight: 500;
   line-height: ${th('lineHeightBase')};
-  min-height: ${grid(3)};
-  min-width: ${grid(5)};
+  min-height: ${grid(6)};
+  min-width: ${grid(10)};
   ${props =>
     props.$isCompact
       ? ''
@@ -60,12 +60,12 @@ const Button = styled(BaseButton)`
 `
 
 const LabelOnlySpan = styled.span`
-  padding: 0 ${grid(1.5)};
+  padding: 0 ${grid(3)};
 `
 
 const Spinner = styled.div`
   display: inline-block;
-  padding-left: ${grid(1)};
+  padding-left: ${grid(2)};
   vertical-align: -2px;
 
   &::after {
@@ -78,17 +78,17 @@ const Spinner = styled.div`
     /* stylelint-disable-next-line string-quotes */
     content: '';
     display: block;
-    height: ${grid(2)};
-    width: ${grid(2)};
+    height: ${grid(4)};
+    width: ${grid(4)};
   }
 `
 
 const IconContainer = styled.div`
   display: inline-block;
-  height: ${grid(2)};
-  margin-left: ${grid(1)};
+  height: ${grid(4)};
+  margin-left: ${grid(2)};
   vertical-align: -2px;
-  width: ${grid(2)};
+  width: ${grid(4)};
 `
 
 /** A styled button with optional status icon/spinner and optional color. Supported statuses are 'pending', 'success', 'failure'. */

--- a/packages/client/app/components/shared/Alert.jsx
+++ b/packages/client/app/components/shared/Alert.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { grid } from '@coko/client'
 
 const StyledAntAlert = styled(AntAlert)`
-  margin-bottom: ${({ $marginBottom }) => grid($marginBottom) ?? 0};
+  margin-bottom: ${({ $marginBottom }) => grid($marginBottom * 2) ?? 0};
 `
 
 const Alert = ({

--- a/packages/client/app/components/shared/Badge.jsx
+++ b/packages/client/app/components/shared/Badge.jsx
@@ -28,9 +28,9 @@ export const Status = styled.span.attrs({
   font-size: 10px;
   font-weight: 700;
   line-height: 0.5;
-  padding-block: ${grid(1.2)};
-  padding-left: ${p => p.$pLeft || grid(1.2)};
-  padding-right: ${p => p.$pRight || grid(1.2)};
+  padding-block: ${grid(2.4)};
+  padding-left: ${p => p.$pLeft || grid(2.4)};
+  padding-right: ${p => p.$pRight || grid(2.4)};
   text-rendering: optimizelegibility;
   text-shadow: ${p => (p.$textShadow ? '0 0 2px #0005' : '')};
   text-transform: uppercase;
@@ -110,7 +110,7 @@ export const StatusBadge = ({
         <Status
           $bg={publishedBg}
           $bRadius={`${bRadius} 0 0 ${bRadius}`}
-          $pRight={!forceToPublished && grid(1)}
+          $pRight={!forceToPublished && grid(2)}
           $text={publishedText}
           $textShadow={publishedText === themeValues.color.textReverse}
         >
@@ -123,7 +123,7 @@ export const StatusBadge = ({
           $bRadius={
             showPublishedStatus ? `0 ${bRadius} ${bRadius} 0` : `${bRadius}`
           }
-          $pLeft={showPublishedStatus && grid(1)}
+          $pLeft={showPublishedStatus && grid(2)}
           $text={text}
           $textShadow={text === themeValues.color.textReverse}
         >

--- a/packages/client/app/components/shared/Calendar.jsx
+++ b/packages/client/app/components/shared/Calendar.jsx
@@ -14,7 +14,7 @@ const Calendar = styled(UnstyledCalendar)`
     background-color: ${th('color.backgroundC')};
     display: flex;
     font-size: ${th('fontSizeBaseSmall')};
-    height: ${grid(4)};
+    height: ${grid(8)};
     justify-content: center;
     line-height: ${th('lineHeightBaseSmall')};
     margin-bottom: 0;
@@ -31,7 +31,7 @@ const Calendar = styled(UnstyledCalendar)`
   }
 
   & .react-calendar__tile {
-    border-radius: ${grid(2)};
+    border-radius: ${grid(4)};
     box-sizing: border-box;
   }
 
@@ -102,16 +102,16 @@ const Calendar = styled(UnstyledCalendar)`
       .react-calendar__tile--hover:not(.react-calendar__tile--hoverStart)
     ),
   & .react-calendar__tile--hoverStart {
-    border-bottom-left-radius: ${grid(2)};
-    border-top-left-radius: ${grid(2)};
+    border-bottom-left-radius: ${grid(4)};
+    border-top-left-radius: ${grid(4)};
   }
 
   &.react-calendar__tile--rangeEnd:not(
       .react-calendar__tile--hover:not(.react-calendar__tile--hoverEnd)
     ),
   & .react-calendar__tile--hoverEnd {
-    border-bottom-right-radius: ${grid(2)};
-    border-top-right-radius: ${grid(2)};
+    border-bottom-right-radius: ${grid(4)};
+    border-top-right-radius: ${grid(4)};
   }
 `
 

--- a/packages/client/app/components/shared/Checkbox.jsx
+++ b/packages/client/app/components/shared/Checkbox.jsx
@@ -29,7 +29,7 @@ const CheckboxContainer = styled.div`
   }
 
   label {
-    margin-left: ${grid(0.9375)};
+    margin-left: ${grid(1.875)};
   }
 `
 

--- a/packages/client/app/components/shared/Collapse.jsx
+++ b/packages/client/app/components/shared/Collapse.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 
 const StyledCollapse = styled(AntCollapse)`
-  padding: 0 ${grid(2)};
+  padding: 0 ${grid(4)};
   width: 100%;
 `
 

--- a/packages/client/app/components/shared/CommsErrorBanner.jsx
+++ b/packages/client/app/components/shared/CommsErrorBanner.jsx
@@ -7,8 +7,8 @@ const ErrorBox = styled.div`
   border-radius: ${th('borderRadius')};
   color: #e33;
   font-size: ${th('fontSizeHeading5')};
-  margin: ${grid(3)};
-  padding: ${grid(2)} ${grid(3)};
+  margin: ${grid(6)};
+  padding: ${grid(4)} ${grid(6)};
 `
 
 const CommsErrorBanner = ({ error }) => {

--- a/packages/client/app/components/shared/Containers.jsx
+++ b/packages/client/app/components/shared/Containers.jsx
@@ -3,7 +3,7 @@ import { grid } from '@coko/client'
 
 export const LooseRowAlignTop = styled.div`
   display: flex;
-  gap: ${grid(3)};
+  gap: ${grid(6)};
   width: 100%;
 `
 
@@ -28,7 +28,7 @@ export const LooseRowSpacedAlignTop = styled(LooseRowAlignTop)`
 `
 
 export const MediumRow = styled(LooseRow)`
-  gap: ${grid(1)};
+  gap: ${grid(2)};
 `
 
 export const MediumRowSpaced = styled(MediumRow)`
@@ -36,7 +36,7 @@ export const MediumRowSpaced = styled(MediumRow)`
 `
 
 export const TightRow = styled(LooseRow)`
-  gap: ${grid(0.5)};
+  gap: ${grid(1)};
 `
 
 export const SolidColumn = styled.div`
@@ -45,15 +45,15 @@ export const SolidColumn = styled.div`
 `
 
 export const TightColumn = styled(SolidColumn)`
-  gap: ${grid(0.5)};
-`
-
-export const MediumColumn = styled(SolidColumn)`
   gap: ${grid(1)};
 `
 
-export const LooseColumn = styled(SolidColumn)`
+export const MediumColumn = styled(SolidColumn)`
   gap: ${grid(2)};
+`
+
+export const LooseColumn = styled(SolidColumn)`
+  gap: ${grid(4)};
 `
 
 export const WidthLimiter = styled.div`

--- a/packages/client/app/components/shared/DatePicker.jsx
+++ b/packages/client/app/components/shared/DatePicker.jsx
@@ -10,7 +10,7 @@ const StyledDatePicker = styled(UnstyledDatePicker)`
   & > div.react-date-picker__wrapper {
     border-color: ${th('colorBorder')};
     border-radius: ${th('borderRadius')};
-    height: ${grid(5)};
+    height: ${grid(10)};
   }
 `
 

--- a/packages/client/app/components/shared/DateRangeCalendar.jsx
+++ b/packages/client/app/components/shared/DateRangeCalendar.jsx
@@ -15,8 +15,8 @@ const MainContainer = styled.div`
   border: 2px solid ${th('colorBorder')};
   box-shadow: ${th('boxShadow200')};
   display: flex;
-  gap: ${grid(1)};
-  padding: ${grid(2)};
+  gap: ${grid(2)};
+  padding: ${grid(4)};
 `
 
 const LeftControls = styled.div`
@@ -29,12 +29,12 @@ const PresetsContainer = styled.div`
   align-items: flex-start;
   display: flex;
   flex-direction: column;
-  gap: ${grid(0.5)};
+  gap: ${grid(1)};
 `
 
 const VerticalDivider = styled.div`
   border-left: 2px solid ${th('colorFurniture')};
-  margin: ${grid(1)};
+  margin: ${grid(2)};
   width: 0;
 `
 

--- a/packages/client/app/components/shared/DescriptionList.jsx
+++ b/packages/client/app/components/shared/DescriptionList.jsx
@@ -3,5 +3,5 @@ import { th, grid } from '@coko/client'
 
 export const DescriptionList = styled.div`
   background-color: ${th('colorBackground')};
-  padding: ${grid(2)} ${grid(3)};
+  padding: ${grid(4)} ${grid(6)};
 `

--- a/packages/client/app/components/shared/FilesUpload.jsx
+++ b/packages/client/app/components/shared/FilesUpload.jsx
@@ -15,10 +15,10 @@ const Root = styled.div`
   border: 1px dashed ${th('color.gray60')};
   border-radius: ${th('borderRadius')};
   display: flex;
-  height: ${grid(8)};
+  height: ${grid(16)};
   justify-content: center;
-  /* line-height: ${grid(8)}; */
-  padding: 0 ${grid(1)};
+  /* line-height: ${grid(16)}; */
+  padding: 0 ${grid(2)};
   text-align: center;
   white-space: nowrap;
   width: fit-content;
@@ -26,8 +26,8 @@ const Root = styled.div`
 
 const Files = styled.div`
   display: flex;
-  gap: ${grid(2)};
-  margin-top: ${grid(2)};
+  gap: ${grid(4)};
+  margin-top: ${grid(4)};
 `
 
 const Message = styled.div`
@@ -39,7 +39,7 @@ const Message = styled.div`
   width: 100%;
 
   svg {
-    margin-left: ${grid(1)};
+    margin-left: ${grid(2)};
   }
 `
 

--- a/packages/client/app/components/shared/General.jsx
+++ b/packages/client/app/components/shared/General.jsx
@@ -5,7 +5,7 @@ import { TabsContainer } from './Tabs'
 export const Section = styled.section.attrs({
   'data-testid': 'section',
 })`
-  padding: ${grid(2)} ${grid(3)};
+  padding: ${grid(4)} ${grid(6)};
 `
 
 export const Content = styled.div`
@@ -17,7 +17,7 @@ export const Content = styled.div`
 
 export const ScrollableContent = styled(Content)`
   @media (width <= 1400px) {
-    margin-top: ${grid(2)};
+    margin-top: ${grid(4)};
     overflow-x: scroll;
   }
 `
@@ -31,14 +31,14 @@ export const SectionContent = styled(Section)`
   /* stylelint-disable-next-line */
   ${TabsContainer} + & {
     border-top-left-radius: 0;
-    margin-bottom: calc(${th('gridUnit')} * 3);
+    margin-bottom: ${grid(6)};
     margin-top: 0;
   }
 
   /* stylelint-disable-next-line */
   ${TabsContainer} ~ div > & {
     border-top-left-radius: 0;
-    margin-bottom: calc(${th('gridUnit')} * 3);
+    margin-bottom: ${grid(6)};
     margin-top: 0;
   }
 
@@ -50,15 +50,15 @@ export const SectionContent = styled(Section)`
 `
 
 export const PaddedContent = styled(Content)`
-  margin-bottom: ${grid(3)};
-  margin-top: ${grid(3)};
-  padding: ${grid(2)} ${grid(3)};
+  margin-bottom: ${grid(6)};
+  margin-top: ${grid(6)};
+  padding: ${grid(4)} ${grid(6)};
 `
 
 export const Container = styled.div`
   background: ${th('color.backgroundC')};
   overflow-y: auto;
-  padding: ${grid(2)};
+  padding: ${grid(4)};
   width: 100%;
 `
 
@@ -71,12 +71,12 @@ export const Title = styled.h2.attrs({
 
 export const SectionHeader = styled.div`
   border-bottom: 1px solid ${th('color.gray90')};
-  padding: ${grid(2)} ${grid(3)};
+  padding: ${grid(4)} ${grid(6)};
 `
 
 export const SectionRow = styled.div`
   border-bottom: 1px solid ${th('color.gray90')};
-  padding: ${grid(2)} ${grid(3)};
+  padding: ${grid(4)} ${grid(6)};
 `
 
 export const ClickableSectionRow = styled(SectionRow)`
@@ -97,7 +97,7 @@ export const ClickableSectionRow = styled(SectionRow)`
 `
 export const SectionRowGrid = styled(SectionRow)`
   display: grid;
-  gap: ${grid(2)};
+  gap: ${grid(4)};
   grid-template-columns: ${props =>
     props.$expandedWidthDetails ? '1fr 3fr' : 'repeat(4, minmax(0, 1fr))'};
 `
@@ -109,11 +109,11 @@ export const SectionAction = styled.div`
 
 export const SectionActionInfo = styled.div`
   grid-column: 1 / span 2;
-  line-height: ${grid(5)};
+  line-height: ${grid(10)};
 `
 
 const Page = styled.div`
-  padding: ${grid(2)};
+  padding: ${grid(4)};
 `
 
 const Heading = styled.div.attrs({
@@ -130,7 +130,7 @@ const Heading = styled.div.attrs({
 
 const FlexRow = styled.div`
   display: flex;
-  gap: ${grid(1)};
+  gap: ${grid(2)};
   justify-content: space-between;
 `
 
@@ -139,7 +139,7 @@ export { FlexRow, Page, Heading }
 export const HeadingWithAction = styled.div`
   align-items: center;
   display: grid;
-  gap: ${grid(2)};
+  gap: ${grid(4)};
   grid-template-columns: 1fr auto;
 `
 
@@ -165,7 +165,7 @@ export const Manuscript = styled.div`
   grid-area: manuscript;
   height: 100vh;
   overflow: auto;
-  padding: ${grid(2)};
+  padding: ${grid(4)};
 `
 
 export const Chat = styled.div`

--- a/packages/client/app/components/shared/HiddenTabs.jsx
+++ b/packages/client/app/components/shared/HiddenTabs.jsx
@@ -43,8 +43,8 @@ export const Tab = styled.div.attrs(props => ({
   cursor: pointer;
   font-size: ${th('fontSizeBaseSmall')};
   font-weight: 500;
-  margin-right: ${grid(0.9375)};
-  padding: calc(${th('gridUnit')} - 1px) 1em;
+  margin-right: ${grid(1.875)};
+  padding: calc(${grid(2)} - 1px) 1em;
   padding-bottom: 0;
   position: relative;
   z-index: 6;

--- a/packages/client/app/components/shared/Icon.jsx
+++ b/packages/client/app/components/shared/Icon.jsx
@@ -5,7 +5,7 @@ import upperFirst from 'lodash/upperFirst'
 import camelCase from 'lodash/camelCase'
 import * as icons from 'react-feather'
 import styled from 'styled-components'
-import { th } from '@coko/client'
+import { grid } from '@coko/client'
 
 const IconWrapper = styled.div`
   align-items: center;
@@ -18,9 +18,9 @@ const IconWrapper = styled.div`
   top: ${props => props.top || 0};
 
   svg {
-    height: calc(${props => props.size} * ${th('gridUnit')});
+    height: ${props => grid(props.size * 2)(props)};
     stroke: ${props => props.$iconColor || props.theme.colorText};
-    width: calc(${props => props.size} * ${th('gridUnit')});
+    width: ${props => grid(props.size * 2)(props)};
   }
 `
 

--- a/packages/client/app/components/shared/LabelBadge.jsx
+++ b/packages/client/app/components/shared/LabelBadge.jsx
@@ -26,7 +26,7 @@ export const ColorBadge = styled(BadgeDiv)`
         : ''};
     `}
   overflow-wrap: normal;
-  padding: ${grid(0.5)} ${grid(1)};
+  padding: ${grid(1)} ${grid(2)};
 `
 
 /** Displays the label as a badge colored according to props.color, with small all-caps font */

--- a/packages/client/app/components/shared/MinimalButton.jsx
+++ b/packages/client/app/components/shared/MinimalButton.jsx
@@ -14,9 +14,9 @@ const BareButton = styled.button`
   font-weight: inherit;
   justify-content: center;
   line-height: inherit;
-  min-height: ${grid(3)};
-  min-width: ${grid(3)};
-  padding: 0 ${grid(0.5)};
+  min-height: ${grid(6)};
+  min-width: ${grid(6)};
+  padding: 0 ${grid(1)};
 
   &:hover {
     color: ${th('color.brand1.base')};

--- a/packages/client/app/components/shared/MinimalDatePicker.jsx
+++ b/packages/client/app/components/shared/MinimalDatePicker.jsx
@@ -15,8 +15,8 @@ const MainContainer = styled.div`
   border: 2px solid ${th('colorBorder')};
   box-shadow: ${th('boxShadow200')};
   display: flex;
-  gap: ${grid(1)};
-  padding: ${grid(2)};
+  gap: ${grid(2)};
+  padding: ${grid(4)};
 `
 
 const DatePickerCalendar = ({

--- a/packages/client/app/components/shared/MinimalNumericUpDown.jsx
+++ b/packages/client/app/components/shared/MinimalNumericUpDown.jsx
@@ -15,10 +15,10 @@ const UpDownButton = styled.button`
   background: none;
   border: none;
   color: ${th('color.gray60')};
-  height: ${grid(2)};
+  height: ${grid(4)};
   justify-content: center;
-  padding: 0 ${grid(0.5)};
-  width: ${grid(3)};
+  padding: 0 ${grid(1)};
+  width: ${grid(6)};
 
   &:hover {
     color: ${th('color.brand1.base')};

--- a/packages/client/app/components/shared/PageError.jsx
+++ b/packages/client/app/components/shared/PageError.jsx
@@ -8,8 +8,8 @@ const ErrorBox = styled.div`
   border-radius: ${th('borderRadius')};
   color: #e33;
   font-size: ${th('fontSizeHeading5')};
-  margin: ${grid(3)};
-  padding: ${grid(2)} ${grid(3)};
+  margin: ${grid(6)};
+  padding: ${grid(4)} ${grid(6)};
 `
 
 const PageError = ({ errorCode }) => {

--- a/packages/client/app/components/shared/Pagination.jsx
+++ b/packages/client/app/components/shared/Pagination.jsx
@@ -18,7 +18,7 @@ export const PaginationContainer = styled.div.attrs(props => ({
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  padding: ${grid(2)} ${grid(3)};
+  padding: ${grid(4)} ${grid(6)};
 `
 
 export const PaginationContainerShadowed = styled(PaginationContainer).attrs(
@@ -51,7 +51,7 @@ const Styles = styled.div`
 
     a {
       display: block;
-      padding: ${grid(1)} ${grid(2)};
+      padding: ${grid(2)} ${grid(4)};
     }
   }
 

--- a/packages/client/app/components/shared/Radio.jsx
+++ b/packages/client/app/components/shared/Radio.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 
 import styled, { css } from 'styled-components'
-import { th, override } from '@coko/client'
+import { grid, override } from '@coko/client'
 
 const Label = styled.span`
   ${props =>
@@ -15,7 +15,7 @@ const Label = styled.span`
 `
 
 const Input = styled.input`
-  margin-right: ${th('gridUnit')};
+  margin-right: ${grid(2)};
   ${override('ui.Radio.Input')};
 `
 
@@ -24,7 +24,7 @@ const Root = styled.label`
   color: ${props => (props.color ? props.color : props.theme.colorText)};
   cursor: pointer;
   display: ${props => (props.inline ? 'inline-flex' : 'flex')};
-  min-height: calc(${th('gridUnit')} * 3);
+  min-height: ${grid(6)};
 
   ${override('ui.Radio')};
 `

--- a/packages/client/app/components/shared/SecondaryActionButton.jsx
+++ b/packages/client/app/components/shared/SecondaryActionButton.jsx
@@ -13,8 +13,8 @@ const BaseButton = styled.button`
   font-size: ${th('fontSizeBase')};
   font-weight: 500;
   line-height: ${th('lineHeightBase')};
-  min-height: ${grid(3)};
-  min-width: ${grid(5)};
+  min-height: ${grid(6)};
+  min-width: ${grid(10)};
   ${props =>
     props.isCompact
       ? ''
@@ -46,12 +46,12 @@ const Button = styled(BaseButton)`
 const LabelOnlySpan = styled.span.attrs({
   'data-testid': 'secondary-action-button-label-only-span',
 })`
-  padding: 0 ${grid(1)};
+  padding: 0 ${grid(2)};
 `
 
 const Spinner = styled.div`
   display: inline-block;
-  padding-left: ${grid(1)};
+  padding-left: ${grid(2)};
   vertical-align: -2px;
 
   &::after {
@@ -63,17 +63,17 @@ const Spinner = styled.div`
     box-sizing: border-box;
     content: '';
     display: block;
-    height: ${grid(2)};
-    width: ${grid(2)};
+    height: ${grid(4)};
+    width: ${grid(4)};
   }
 `
 
 const IconContainer = styled.div`
   display: inline-block;
-  height: ${grid(2)};
-  margin-left: ${grid(1)};
+  height: ${grid(4)};
+  margin-left: ${grid(2)};
   vertical-align: -2px;
-  width: ${grid(2)};
+  width: ${grid(4)};
 `
 
 const SecondaryActionButton = ({

--- a/packages/client/app/components/shared/Select.jsx
+++ b/packages/client/app/components/shared/Select.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types'
 import ReactSelect, { components } from 'react-select'
 import styled, { ThemeContext } from 'styled-components'
 import { useTranslation } from 'react-i18next'
+import { grid } from '@coko/client'
 
 const styles = theme => ({
   menuPortal: provided => ({
@@ -44,7 +45,7 @@ const styles = theme => ({
       boxShadow: `1px solid ${theme.color.gray70}`,
     },
     fontSize: theme.fontSizeBaseSmall,
-    minHeight: `calc(${theme.gridUnit} * 5)`,
+    minHeight: grid(10)({ theme }),
     div: {
       color: theme.color.gray20,
     },

--- a/packages/client/app/components/shared/SortIcons.jsx
+++ b/packages/client/app/components/shared/SortIcons.jsx
@@ -3,9 +3,9 @@ import { ArrowUp, ArrowDown } from 'react-feather'
 import { th, grid } from '@coko/client'
 
 export const SortUp = styled(ArrowUp)`
-  height: ${grid(2)};
+  height: ${grid(4)};
   stroke: ${th('colorBorder')};
-  width: ${grid(2)};
+  width: ${grid(4)};
 
   &:hover {
     stroke: ${th('colorPrimary')};
@@ -13,9 +13,9 @@ export const SortUp = styled(ArrowUp)`
 `
 
 export const SortDown = styled(ArrowDown)`
-  height: ${grid(2)};
+  height: ${grid(4)};
   stroke: ${th('colorBorder')};
-  width: ${grid(2)};
+  width: ${grid(4)};
 
   &:hover {
     stroke: ${th('colorPrimary')};

--- a/packages/client/app/components/shared/Spinner.jsx
+++ b/packages/client/app/components/shared/Spinner.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { rotate360, th } from '@coko/client'
+import { grid, rotate360, th } from '@coko/client'
 
 // Courtesy of loading.io/css
 const SpinnerAnimation = styled.div`
@@ -28,7 +28,7 @@ const LoadingPage = styled.div.attrs({
   display: flex;
   height: 100%;
   justify-content: center;
-  padding-bottom: calc(${th('gridUnit')} * 2);
+  padding-bottom: ${grid(4)};
   width: 100%;
 `
 

--- a/packages/client/app/components/shared/Table.jsx
+++ b/packages/client/app/components/shared/Table.jsx
@@ -7,7 +7,7 @@ export const Table = styled.table`
   border-collapse: collapse;
   border-radius: ${th('borderRadius')};
   font-size: ${th('fontSizeBaseSmall')};
-  margin-top: ${grid(2)};
+  margin-top: ${grid(4)};
   table-layout: fixed;
   width: 100%;
 
@@ -24,13 +24,13 @@ export const Header = styled.thead`
   text-align: left;
 
   th {
-    padding: ${grid(1)} ${grid(3)};
+    padding: ${grid(2)} ${grid(6)};
   }
 `
 
 export const Row = styled.tr`
   border-bottom: 1px solid ${th('colorFurniture')};
-  max-height: ${grid(8)};
+  max-height: ${grid(16)};
 
   &:hover {
     background-color: ${th('colorBackgroundHue')};
@@ -39,7 +39,7 @@ export const Row = styled.tr`
 
 export const Cell = styled.td`
   ${({ minWidth }) => minWidth && `min-width: ${minWidth}`};
-  padding: calc(${grid(2)} - 1px) ${grid(3)} ${grid(2)} ${grid(3)};
+  padding: calc(${grid(4)} - 1px) ${grid(6)} ${grid(4)} ${grid(6)};
 
   button {
     font-size: ${th('fontSizeBaseSmall')};

--- a/packages/client/app/components/shared/Tabs.jsx
+++ b/packages/client/app/components/shared/Tabs.jsx
@@ -27,8 +27,8 @@ const Tab = styled.div`
   cursor: pointer;
   font-size: ${th('fontSizeBaseSmall')};
   font-weight: 500;
-  margin-right: ${grid(0.9375)};
-  padding: calc(${th('gridUnit')} - 1px) 1em;
+  margin-right: ${grid(1.875)};
+  padding: calc(${grid(2)} - 1px) 1em;
   padding-bottom: 2px;
 
   & > div {

--- a/packages/client/app/components/shared/Tag.jsx
+++ b/packages/client/app/components/shared/Tag.jsx
@@ -14,7 +14,7 @@ const Tag = ({ children, color, fontSize = 'baseSmall', variant }) => {
       color={theme[colorLabel]}
       style={{
         fontSize: theme[fontSizeLabel],
-        padding: `${grid(2)} ${grid(4)}`,
+        padding: `${grid(4)} ${grid(8)}`,
       }}
       variant={variant}
     >

--- a/packages/client/app/components/shared/UploadingFile.jsx
+++ b/packages/client/app/components/shared/UploadingFile.jsx
@@ -10,16 +10,16 @@ import { ConfirmationModal } from '../component-modal/src/ConfirmationModal'
 
 const Icon = styled.div`
   background: ${th('color.gray90')};
-  height: ${grid(10)};
-  margin-bottom: ${th('gridUnit')};
+  height: ${grid(20)};
+  margin-bottom: ${grid(2)};
   opacity: 0.5;
   overflow: hidden;
-  padding: ${grid(1)};
+  padding: ${grid(2)};
   position: relative;
-  width: ${grid(10)};
+  width: ${grid(20)};
 
   img {
-    width: ${grid(8)};
+    width: ${grid(16)};
   }
 `
 
@@ -27,13 +27,13 @@ const Extension = styled.div`
   background: ${th('color.gray5')};
   color: ${th('color.textReverse')};
   font-size: ${th('fontSizeBaseSmall')};
-  left: ${grid(2)};
+  left: ${grid(4)};
   line-height: ${th('lineHeightBaseSmall')};
   position: absolute;
   right: 0;
   text-align: center;
   text-transform: uppercase;
-  top: ${grid(2)};
+  top: ${grid(4)};
 `
 
 const Filename = styled.div`
@@ -41,7 +41,7 @@ const Filename = styled.div`
   font-size: ${th('fontSizeBaseSmall')};
   font-style: italic;
   line-height: ${th('lineHeightBaseSmall')};
-  max-width: ${grid(12)};
+  max-width: ${grid(24)};
   overflow: hidden;
   text-overflow: ellipsis;
 `
@@ -50,8 +50,8 @@ const Uploading = styled.div`
   align-items: center;
   display: block;
   flex-direction: column;
-  margin-bottom: ${grid(3)};
-  margin-right: ${grid(3)};
+  margin-bottom: ${grid(6)};
+  margin-right: ${grid(6)};
   position: relative;
 `
 
@@ -81,7 +81,7 @@ const ErrorWrapper = styled.div`
   letter-spacing: 0.01em;
   line-height: ${th('lineHeightBaseSmall')};
   opacity: 1;
-  padding: ${th('gridUnit')} ${th('gridUnit')};
+  padding: ${grid(2)} ${grid(2)};
   position: absolute;
   top: 25%;
   z-index: 4;

--- a/packages/client/app/components/shared/UserCombo.jsx
+++ b/packages/client/app/components/shared/UserCombo.jsx
@@ -4,7 +4,7 @@ import { th, grid } from '@coko/client'
 export const UserCombo = styled.div`
   align-items: center;
   display: flex;
-  line-height: ${grid(2.5)};
+  line-height: ${grid(5)};
 `
 
 export const Primary = styled.b.attrs({
@@ -18,5 +18,5 @@ export const Secondary = styled.div`
 `
 
 export const UserInfo = styled.div`
-  margin-left: ${grid(1)};
+  margin-left: ${grid(2)};
 `

--- a/packages/client/app/components/shared/VersionSwitcher.jsx
+++ b/packages/client/app/components/shared/VersionSwitcher.jsx
@@ -23,7 +23,7 @@ const Container = styled.div`
   display: flex;
   flex: 1;
   flex-direction: column;
-  margin-top: ${grid(2)};
+  margin-top: ${grid(4)};
   min-height: 0;
   overflow: hidden;
 `

--- a/packages/client/app/theme/elements/Button.jsx
+++ b/packages/client/app/theme/elements/Button.jsx
@@ -1,5 +1,5 @@
 import { css } from 'styled-components'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 
 const secondary = css`
   background: none;
@@ -34,8 +34,8 @@ const secondary = css`
 export default css`
   border: none;
   font-weight: 500;
-  line-height: calc(${th('gridUnit')} * 3);
-  min-width: calc(${th('gridUnit')} * 16);
+  line-height: ${grid(6)};
+  min-width: ${grid(32)};
   ${props => !props.$primary && secondary};
 
   &:focus,

--- a/packages/client/app/theme/elements/GlobalStyle.jsx
+++ b/packages/client/app/theme/elements/GlobalStyle.jsx
@@ -58,11 +58,11 @@ const globalStyles = css`
   /* Ant notifications */
 
   .ant-notification-notice {
-    padding: ${grid(3)} !important;
+    padding: ${grid(6)} !important;
 
     > button {
-      top: calc(${grid(3)} + 3px) !important;
-      right: ${grid(3)} !important;
+      top: calc(${grid(6)} + 3px) !important;
+      right: ${grid(6)} !important;
     }
   }
 

--- a/packages/client/app/theme/elements/Radio.jsx
+++ b/packages/client/app/theme/elements/Radio.jsx
@@ -1,7 +1,7 @@
 /* stylelint-disable string-quotes */
 
 import { css, keyframes } from 'styled-components'
-import { th } from '@coko/client'
+import { grid, th } from '@coko/client'
 
 const checking = keyframes`
   0% {
@@ -45,22 +45,22 @@ export default {
       background: ${props => (props.checked ? 'currentColor' : 'transparent')};
 
       /* This is not a real border (box-shadow provides that), so not themed as such */
-      border: calc(${th('gridUnit')} / 4) solid white;
+      border: ${grid(0.5)} solid white;
       border-radius: 50%;
       box-shadow: 0 0 0 ${th('borderWidth')} currentColor;
 
       color: ${props => (props.color ? props.color : props.theme.color.text)};
       content: ' ';
       display: inline-block;
-      height: calc(${th('gridUnit')} * 2);
-      margin-left: ${th('gridUnit')};
-      margin-right: ${th('gridUnit')};
+      height: ${grid(4)};
+      margin-left: ${grid(2)};
+      margin-right: ${grid(2)};
 
       transition: border ${th('transitionDuration')}
         ${th('transitionTimingFunction')};
 
       vertical-align: middle;
-      width: calc(${th('gridUnit')} * 2);
+      width: ${grid(4)};
     }
   `,
   Input: css`

--- a/packages/client/app/theme/elements/TextField.jsx
+++ b/packages/client/app/theme/elements/TextField.jsx
@@ -54,6 +54,6 @@ export default {
   `,
 
   Label: css`
-    margin-bottom: ${grid(1)};
+    margin-bottom: ${grid(2)};
   `,
 }

--- a/packages/client/app/theme/index.jsx
+++ b/packages/client/app/theme/index.jsx
@@ -210,7 +210,7 @@ export const makeTheme = (
   lineHeightHeading1: '1.1',
 
   /* Spacing */
-  gridUnit: '8px',
+  gridUnit: '4px',
 
   /* Border */
   borderRadius: '3px',

--- a/packages/client/app/ui/base/ErrorPageFallback.tsx
+++ b/packages/client/app/ui/base/ErrorPageFallback.tsx
@@ -16,11 +16,11 @@ const Container = styled.div`
 const Content = styled.div`
   margin-bottom: 1rem;
   max-width: 40em;
-  padding: ${grid(4)};
+  padding: ${grid(8)};
   text-align: center;
 
   h1 {
-    margin-bottom: ${grid(2)};
+    margin-bottom: ${grid(4)};
   }
 `
 

--- a/packages/client/app/ui/base/Menu.tsx
+++ b/packages/client/app/ui/base/Menu.tsx
@@ -42,7 +42,7 @@ const Wrapper = styled.nav<{ $menuCollapsed: boolean }>`
   transition: width ${collapseTransition};
   will-change: width;
 
-  padding: ${grid(1)} 0;
+  padding: ${grid(2)} 0;
 
   display: flex;
   flex-direction: column;
@@ -54,7 +54,7 @@ const Wrapper = styled.nav<{ $menuCollapsed: boolean }>`
 `
 
 const GroupSection = styled.div`
-  margin: ${grid(1)} ${grid(1)} 0 ${grid(1)};
+  margin: ${grid(2)} ${grid(2)} 0 ${grid(2)};
   display: flex;
   align-items: center;
   font-family: ${th('fontInterface')};
@@ -62,8 +62,8 @@ const GroupSection = styled.div`
 `
 
 const GroupLetter = styled.div<{ $menuCollapsed: boolean }>`
-  height: ${grid(6)};
-  width: ${grid(6)};
+  height: ${grid(12)};
+  width: ${grid(12)};
   border-radius: ${th('borderRadiusLarge')};
 
   background-color: ${th('colorBackground')};
@@ -76,16 +76,16 @@ const GroupLetter = styled.div<{ $menuCollapsed: boolean }>`
   flex-shrink: 0;
 
   margin-left: ${(props): string =>
-    props.$menuCollapsed ? '0' : grid(1)(props)};
+    props.$menuCollapsed ? '0' : grid(2)(props)};
   margin-right: ${(props): string =>
-    props.$menuCollapsed ? '0' : grid(1.5)(props)};
+    props.$menuCollapsed ? '0' : grid(3)(props)};
   transition: margin ${collapseTransition};
 `
 
 const GroupRight = styled.div<{ $menuCollapsed: boolean }>`
   display: flex;
   flex-direction: column;
-  padding-top: ${grid(0.75)};
+  padding-top: ${grid(1.5)};
 
   visibility: ${(props): string =>
     props.$menuCollapsed ? 'hidden' : 'visible'};
@@ -108,12 +108,12 @@ const GroupType = styled.div`
 const Separator = styled.div`
   height: 1px;
   /* background-color: ${th('colorBackground')}; */
-  margin: ${grid(2)} ${grid(0.5)};
+  margin: ${grid(4)} ${grid(1)};
   border-top: 1.5px solid ${th('colorBackground')};
 `
 
 const LinkSection = styled.div`
-  padding: 0 ${grid(1)};
+  padding: 0 ${grid(2)};
   user-select: none;
   display: flex;
   flex-direction: column;
@@ -139,8 +139,8 @@ const LinkItem = styled.div<{ $active: boolean }>`
   color: ${th('colorTextReverse')};
   cursor: pointer;
   font-size: ${th('fontSizeBase')};
-  margin-bottom: ${grid(0.5)};
-  padding: ${grid(1)} ${grid(2)};
+  margin-bottom: ${grid(1)};
+  padding: ${grid(2)} ${grid(4)};
   display: flex;
   white-space: nowrap;
 
@@ -150,7 +150,7 @@ const LinkItem = styled.div<{ $active: boolean }>`
 
   > div:first-child {
     flex-shrink: 0;
-    margin-right: ${grid(1)};
+    margin-right: ${grid(2)};
   }
 
   &:hover {
@@ -167,7 +167,7 @@ const Link = styled(UILink)`
 const UserSection = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 0 ${grid(1)} ${grid(1)} ${grid(1)};
+  padding: 0 ${grid(2)} ${grid(2)} ${grid(2)};
   font-family: ${th('fontInterface')};
   line-height: ${th('lineHeightBase')};
 `
@@ -177,10 +177,10 @@ const UserTop = styled.div<{ $menuCollapsed: boolean }>`
   align-items: center;
 
   margin-left: ${(props): string =>
-    props.$menuCollapsed ? '0' : grid(1)(props)};
+    props.$menuCollapsed ? '0' : grid(2)(props)};
   margin-right: ${(props): string =>
-    props.$menuCollapsed ? '0' : grid(1.5)(props)};
-  margin-bottom: ${grid(1)};
+    props.$menuCollapsed ? '0' : grid(3)(props)};
+  margin-bottom: ${grid(2)};
   transition: margin ${collapseTransition};
 
   > a {
@@ -190,7 +190,7 @@ const UserTop = styled.div<{ $menuCollapsed: boolean }>`
 
     > div:first-child {
       flex-shrink: 0;
-      margin-right: ${grid(1)};
+      margin-right: ${grid(2)};
     }
 
     > div:last-child {
@@ -202,7 +202,7 @@ const UserTop = styled.div<{ $menuCollapsed: boolean }>`
 `
 
 const UserBottom = styled.div<{ $menuCollapsed: boolean }>`
-  margin-left: ${grid(1)};
+  margin-left: ${grid(2)};
 
   visibility: ${(props): string =>
     props.$menuCollapsed ? 'hidden' : 'visible'};
@@ -220,7 +220,7 @@ const UserName = styled.div<{ $labelsWrap: boolean }>`
 
 const UserRoles = styled.div<{ $labelsWrap: boolean }>`
   display: flex;
-  gap: ${grid(0.5)};
+  gap: ${grid(1)};
   flex-wrap: ${(props): string => (props.$labelsWrap ? 'wrap' : 'nowrap')};
   overflow: hidden;
 `
@@ -229,7 +229,7 @@ const UserLabel = styled.span`
   background-color: ${th('colorTextReverse')};
   color: ${th('colorPrimary')};
   font-size: ${th('fontSizeBaseSmaller')};
-  padding: 0 ${grid(1)};
+  padding: 0 ${grid(2)};
   border-radius: ${th('borderRadius')};
   white-space: nowrap;
 `

--- a/packages/client/app/ui/shared/Avatar.tsx
+++ b/packages/client/app/ui/shared/Avatar.tsx
@@ -21,8 +21,8 @@ const Img = styled.img`
 const OnlineIndicator = styled.div<{ $online: boolean }>`
   border: 3px solid ${th('colorBackground')};
   border-radius: 50%;
-  height: ${grid(2)};
-  width: ${grid(2)};
+  height: ${grid(4)};
+  width: ${grid(4)};
   background-color: ${(props): string =>
     props.$online ? props.theme.colorPrimary : props.theme.colorDisabled};
 
@@ -42,7 +42,7 @@ type AvatarProps = {
 
 const Avatar = ({
   src,
-  size = 6,
+  size = 12,
   isUserOnline,
   showOnlineIndicator = false,
 }: AvatarProps): ReactNode => {

--- a/packages/client/app/ui/shared/Breadcrumb.tsx
+++ b/packages/client/app/ui/shared/Breadcrumb.tsx
@@ -17,7 +17,7 @@ const flatEdges = css`
       0 100%
     );
 
-    padding-left: ${grid(3)};
+    padding-left: ${grid(6)};
 
     border-top-left-radius: ${th('borderRadius')};
     border-bottom-left-radius: ${th('borderRadius')};
@@ -26,7 +26,7 @@ const flatEdges = css`
   .ant-breadcrumb-item:last-child .ant-breadcrumb-link {
     clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, var(--depth) 50%);
 
-    padding-right: ${grid(3)};
+    padding-right: ${grid(6)};
 
     border-top-right-radius: ${th('borderRadius')};
     border-bottom-right-radius: ${th('borderRadius')};
@@ -41,13 +41,13 @@ const StyledBreadcrumb = styled(AntBreadcrumb)`
   .ant-breadcrumb-link {
     background-color: ${th('colorPrimary')};
     color: ${th('colorTextReverse')};
-    padding: ${grid(1.5)} ${grid(4)};
+    padding: ${grid(3)} ${grid(8)};
     font-weight: 500;
     cursor: pointer;
 
-    margin-left: ${grid(-2)};
+    margin-left: ${grid(-4)};
 
-    --depth: ${grid(2.5)};
+    --depth: ${grid(5)};
 
     clip-path: polygon(
       0 0,

--- a/packages/client/app/ui/shared/CardGrid.tsx
+++ b/packages/client/app/ui/shared/CardGrid.tsx
@@ -17,12 +17,12 @@ const Title = styled(H2)`
 const Description = styled.div`
   flex-grow: 1;
   color: ${th('colorText')};
-  padding-top: ${grid(2)};
+  padding-top: ${grid(4)};
 `
 
 const IconWrapper = styled.div`
   align-self: end;
-  padding-bottom: ${grid(3)};
+  padding-bottom: ${grid(6)};
   opacity: 0;
   transition: opacity 0.3s ease;
 
@@ -33,10 +33,10 @@ const IconWrapper = styled.div`
 `
 
 const Card = styled.div`
-  min-height: ${grid(38)};
+  min-height: ${grid(76)};
   border-radius: ${th('borderRadius')};
   box-shadow: ${th('boxShadow200')};
-  padding: ${grid(6)} ${grid(4)} 0;
+  padding: ${grid(12)} ${grid(8)} 0;
   cursor: pointer;
   background-color: ${th('colorBackground')};
   transition: box-shadow 0.2s ease;
@@ -56,8 +56,8 @@ const Card = styled.div`
 
 const Wrapper = styled.ul`
   display: grid;
-  grid-template-columns: repeat(auto-fill, ${grid(55)});
-  gap: ${grid(4)};
+  grid-template-columns: repeat(auto-fill, ${grid(110)});
+  gap: ${grid(8)};
   list-style: none;
   margin: 0 auto;
   padding: 0;

--- a/packages/client/app/ui/shared/Page.tsx
+++ b/packages/client/app/ui/shared/Page.tsx
@@ -10,7 +10,7 @@ const Wrapper = styled.div`
   height: 100%;
   min-height: 0;
   overflow: auto;
-  padding: ${grid(3)};
+  padding: ${grid(6)};
   font-family: ${th('fontInterface')};
   line-height: ${th('lineHeightBase')};
 `
@@ -18,8 +18,8 @@ const Wrapper = styled.div`
 const Header = styled(H1)`
   /* stylelint-disable declaration-no-important */
   margin-top: 0;
-  margin-bottom: ${grid(3)};
-  padding-bottom: ${grid(1)};
+  margin-bottom: ${grid(6)};
+  padding-bottom: ${grid(2)};
   border-bottom: 2px solid ${th('colorPrimary')};
 
   color: ${th('colorPrimary')} !important;
@@ -33,7 +33,7 @@ const Content = styled.div`
   flex: 1;
   min-height: 0;
   font-size: ${th('fontSizeBase')};
-  padding-bottom: ${grid(3)};
+  padding-bottom: ${grid(6)};
 `
 
 type PageProps = {

--- a/packages/client/app/ui/shared/PageDescription.tsx
+++ b/packages/client/app/ui/shared/PageDescription.tsx
@@ -5,7 +5,7 @@ import { grid, th } from '@coko/client'
 
 const StyledPageDescription = styled.p`
   color: ${th('colorText')};
-  margin-bottom: ${grid(3)};
+  margin-bottom: ${grid(6)};
   max-width: 60em;
 `
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,7 +24,7 @@
     "@codemirror/lang-css": "^6.2.1",
     "@codemirror/lang-html": "^6.4.6",
     "@codemirror/lang-json": "^6.0.1",
-    "@coko/client": "^2.2.1",
+    "@coko/client": "^2.2.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/packages/client/stories/shared/Avatar.stories.tsx
+++ b/packages/client/stories/shared/Avatar.stories.tsx
@@ -18,7 +18,7 @@ export const Base = meta.story({
 export const DifferentSize = meta.story({
   args: {
     src: avatarImg,
-    size: 20,
+    size: 40,
     showOnlineIndicator: true,
     isUserOnline: true,
   },
@@ -27,7 +27,7 @@ export const DifferentSize = meta.story({
 export const DifferentImage = meta.story({
   args: {
     src: avatarImg2,
-    size: 20,
+    size: 40,
     showOnlineIndicator: true,
     isUserOnline: true,
   },

--- a/packages/client/yarn.lock
+++ b/packages/client/yarn.lock
@@ -599,9 +599,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coko/client@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "@coko/client@npm:2.2.1"
+"@coko/client@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@coko/client@npm:2.2.2"
   dependencies:
     "@ant-design/icons": "npm:^6.2.2"
     "@dnd-kit/core": "npm:^6.3.1"
@@ -633,7 +633,7 @@ __metadata:
   bin:
     coko-client-build: ./scripts/coko-client-build.mjs
     coko-client-dev: ./scripts/coko-client-dev.mjs
-  checksum: 10c0/976966f52b66d98df567efac54ebc703481098b2e39e9906675f77780831fce884cc12c3ddf7c47aab828ccd39dc980d631ef291e09e1a6cb84bd9f05c805f56
+  checksum: 10c0/22405483f22cb3506042e7e4cee501b394d4f094b8595aa66899e8b82aa61acec1bc1236b511462d4a9ad5caafe726f45ab850ce58d88e7c39698542cb95f9b6
   languageName: node
   linkType: hard
 
@@ -5381,7 +5381,7 @@ __metadata:
     "@codemirror/lang-css": "npm:^6.2.1"
     "@codemirror/lang-html": "npm:^6.4.6"
     "@codemirror/lang-json": "npm:^6.0.1"
-    "@coko/client": "npm:^2.2.1"
+    "@coko/client": "npm:^2.2.2"
     "@dnd-kit/core": "npm:^6.3.1"
     "@dnd-kit/sortable": "npm:^10.0.0"
     "@dnd-kit/utilities": "npm:^3.2.2"


### PR DESCRIPTION
Related to #411 
* Halves the grid unit to 4px from 8px, in order to avoid values less than 1 grid unit to a larger extent, as well as to align with ant's 4px base unit, which will let us avoid writing a lot of overrides to reduce spacing.
* Updates all usage of grid so that components are visually the same as before.
* Cleans up usage of grid unit without the grid helper.