### PR TITLE
Make sure import job can handle `archivePeriodDays` missing from config

### DIFF
--- a/packages/server/controllers/manuscript/__tests__/manuscriptCommsUtils.test.ts
+++ b/packages/server/controllers/manuscript/__tests__/manuscriptCommsUtils.test.ts
@@ -1,0 +1,40 @@
+import { describe, beforeAll, beforeEach, afterAll, it, expect } from 'vitest'
+import { db, config, DbTestUtils, migrationManager } from '@coko/server'
+
+import Group from '../../../models/group/group.model'
+import Config from '../../../models/config/config.model'
+import { archiveOldManuscripts } from '../manuscriptCommsUtils'
+
+describe('archiveOldManuscripts', () => {
+  beforeAll(async () => {
+    await config.init()
+    db.init()
+    await migrationManager.migrate()
+  })
+
+  beforeEach(async () => {
+    await DbTestUtils.clearDb()
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('archivedOldManuscripts does not crash when archivePeriodDays is not set in the config', async () => {
+    const group = await Group.insert({})
+
+    await Config.insert({
+      active: true,
+      groupId: group.id,
+      formData: {
+        manuscript: {
+          // archivePeriodDays intentionally omitted,
+          // reproducing a config created before this field existed
+        },
+      },
+    })
+
+    const res = await archiveOldManuscripts(group.id)
+    expect(res).not.toBeDefined()
+  })
+})

--- a/packages/server/controllers/manuscript/manuscriptCommsUtils.js
+++ b/packages/server/controllers/manuscript/manuscriptCommsUtils.js
@@ -60,7 +60,13 @@ const archiveOldManuscripts = async groupId => {
   const activeConfig = await Config.getCached(groupId)
 
   const { archivePeriodDays } = activeConfig.formData.manuscript
-  if (Number.isNaN(archivePeriodDays) || archivePeriodDays < 1) return
+  if (
+    typeof archivePeriodDays !== 'number' ||
+    Number.isNaN(archivePeriodDays) ||
+    archivePeriodDays < 1
+  ) {
+    return
+  }
 
   const cutoffDate = new Date(
     new Date().valueOf() - archivePeriodDays * 86400000, // subtracting milliseconds of ARCHIVE_PERIOD_DAYS


### PR DESCRIPTION
This addresses the first of two errors shown in #453.

The issue was that `archivePeriodDays` being undefined in the config passes the check `Number.isNaN(archivePeriodDays) || archivePeriodDays < 1` (undefined is not NaN). This caused an invalid number to be parsed for the postgres query underneath that check, causing the final error shown in the issue.